### PR TITLE
Require type of version provided to bump version to be a string

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       version:
         description: 'Version to bump to (e.g. 0.1.0)'
+        type: 'string'
         required: true
 
 jobs:


### PR DESCRIPTION
### What
Require type of version provided to bump version to be a string.

### Why
The type is required.