### PR TITLE
Set target-dir for cargo bin installs in workflows

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --locked --version 0.2.35 cargo-workspaces
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.2.35 cargo-workspaces
     - run: |
         cargo workspaces version --all --force '*' --no-git-commit --yes custom ${{ inputs.version }}
     - name: Create Commit

--- a/.github/workflows/rust-set-rust-version.yml
+++ b/.github/workflows/rust-set-rust-version.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --locked --version 0.4.0 cargo-set-rust-version --target-dir ~/.cargo/target
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.4.0 cargo-set-rust-version
 
     # Update the rust-version in all workspace crates to the latest stable
     # version.


### PR DESCRIPTION
### What
Set target-dir for cargo bin installs in workflows.

### Why
So that the cargo bin installs are cached.