### PR TITLE
Add action that runs package verification on a workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ live in `.github/workflows/test-*`.
 | [rust-cache] | Action | Caches dependencies, install artifacts, and build artifacts in Rust projects. | [rs-stellar-env] |
 | [rust-set-rust-version] | Reusable Workflow | Updates the rust-version in Rust crates to the latest stable version. | [rs-stellar-env] |
 | [rust-bump-version] | Reusable Workflow | Updates the version in Rust crates to a input version. | [rs-stellar-env] |
+| [rust-workspace-publish-dry-run] | Action | Run publish dry run (package verification) on all crates in a workspace. | [rs-stellar-env] |
 
 [@stellar]: https://github.com/stellar
 
 [rust-cache]: ./rust-cache/action.yml
+[rust-cache]: ./rust-workspace-publish-dry-run/action.yml
 [rust-set-rust-version]: ./.github/workflows/rust-set-rust-version.yml
 [rust-bump-version]: ./.github/workflows/rust-bump-version.yml
 

--- a/rust-workspace-publish-dry-run/action.yml
+++ b/rust-workspace-publish-dry-run/action.yml
@@ -28,7 +28,8 @@ runs:
       do
         name=$(basename "$crate" .crate)
         tar xvfz "$crate" -C vendor/
-        # Crates in the vendor directory require a checksum file.
+        # Crates in the vendor directory require a checksum file, but it doesn't
+        # matter if it is empty.
         echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
       done
 

--- a/rust-workspace-publish-dry-run/action.yml
+++ b/rust-workspace-publish-dry-run/action.yml
@@ -26,7 +26,7 @@ runs:
     run: |
       for crate in target/package/*.crate
       do
-        local name=$(basename "$crate" .crate)
+        name=$(basename "$crate" .crate)
         tar xvfz "$crate" -C vendor/
         # Crates in the vendor directory require a checksum file.
         echo '{"files":{}}' > vendor/$name/.cargo-checksum.json

--- a/rust-workspace-publish-dry-run/action.yml
+++ b/rust-workspace-publish-dry-run/action.yml
@@ -1,0 +1,45 @@
+name: 'Rust Workspace Publish Dry Run'
+description: 'Dry run publish workspace crates.'
+runs:
+  using: "composite"
+  steps:
+
+  - shell: bash
+    run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
+  - shell: bash
+    run: cargo install --target-dir ~/.cargo/target --locked --version 0.1.0 cargo-vendor-add
+
+  # Remove [patch.crates-io] entries in the workspace Cargo.toml that reference
+  # git repos. These will be removed when published.
+  - shell: bash
+    run: sed -i.bak -r '/git ?=/d' Cargo.toml
+
+  # Vendor all the dependencies into the vendor/ folder.
+  - shell: bash
+    run: cargo vendor --versioned-dirs
+
+  # Package the crates that will be published. Verification is disabled because
+  # we aren't ready to verify yet.
+  - shell: bash
+    run: cargo hack --ignore-private package --no-verify
+
+  # Add each crate that was packaged to the vendor/ directory.
+  - shell: bash
+    run: |
+      for crate in target/package/*.crate
+      do
+        cargo vendor-add --crate "$crate" --vendor-path vendor
+      done
+
+  # Rerun the package command but with verification enabled this time. Tell
+  # cargo to use the local vendor/ directory as the source for all packages. Run
+  # the package command on the full feature powerset so that all features of
+  # each crate are verified to compile.
+  - shell: bash
+    run: >
+      cargo hack
+      --feature-powerset
+      --ignore-private
+      --config "source.crates-io.replace-with = 'vendored-sources'"
+      --config "source.vendored-sources.directory = 'vendor'"
+      package

--- a/rust-workspace-publish-dry-run/action.yml
+++ b/rust-workspace-publish-dry-run/action.yml
@@ -6,8 +6,6 @@ runs:
 
   - shell: bash
     run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
-  - shell: bash
-    run: cargo install --target-dir ~/.cargo/target --locked --version 0.1.0 cargo-vendor-add
 
   # Remove [patch.crates-io] entries in the workspace Cargo.toml that reference
   # git repos. These will be removed when published.
@@ -28,7 +26,10 @@ runs:
     run: |
       for crate in target/package/*.crate
       do
-        cargo vendor-add --crate "$crate" --vendor-path vendor
+        local name=$(basename "$crate" .crate)
+        tar xvfz "$crate" -C vendor/
+        # Crates in the vendor directory require a checksum file.
+        echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
       done
 
   # Rerun the package command but with verification enabled this time. Tell


### PR DESCRIPTION
### What
Add action that runs package verification on a workspace

### Why
So that on release branches of our crates we can have confidence that they will compile before starting the publish process.

Unfortunately there is no officially supported or even community specified way to do this, so the process is somewhat of a hack. The process relies entirely on the vendor directory feature of cargo however, which is an official component of cargo and so this hack should be relatively stable.