### PR TITLE
Add cargo package options as an input to the workspace publish dry run

### DIFF
--- a/rust-workspace-publish-dry-run/action.yml
+++ b/rust-workspace-publish-dry-run/action.yml
@@ -1,5 +1,11 @@
 name: 'Rust Workspace Publish Dry Run'
 description: 'Dry run publish workspace crates.'
+
+inputs:
+  options:
+    description: 'options to pass to cargo package'
+    default: ''
+
 runs:
   using: "composite"
   steps:
@@ -19,7 +25,7 @@ runs:
   # Package the crates that will be published. Verification is disabled because
   # we aren't ready to verify yet.
   - shell: bash
-    run: cargo hack --ignore-private package --no-verify
+    run: cargo hack --ignore-private package --no-verify ${{ inputs.cargo-package-options }}
 
   # Add each crate that was packaged to the vendor/ directory.
   - shell: bash
@@ -45,3 +51,4 @@ runs:
       --config "source.crates-io.replace-with = 'vendored-sources'"
       --config "source.vendored-sources.directory = 'vendor'"
       package
+      ${{ inputs.cargo-package-options }}


### PR DESCRIPTION
### What
Add cargo package options as an input to the workspace publish dry run

### Why
So that workflows can specify a target.