### PR TITLE
Fix cargo-package-options input to workspace publish dry run action

### DIFF
--- a/rust-workspace-publish-dry-run/action.yml
+++ b/rust-workspace-publish-dry-run/action.yml
@@ -2,7 +2,7 @@ name: 'Rust Workspace Publish Dry Run'
 description: 'Dry run publish workspace crates.'
 
 inputs:
-  options:
+  cargo-package-options:
     description: 'options to pass to cargo package'
     default: ''
 


### PR DESCRIPTION
### What
Change name of `options` input to `cargo-package-options`.

### Why
That's the name of the input used inside the composite action, and the meta details describing the input is wrong.