### PR TITLE
Add @ symbol to username in bump version workflow

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -37,5 +37,5 @@ jobs:
             repo: context.repo.repo,
             head: 'release/v${{ inputs.version }}',
             base: 'main',
-            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.'
+            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by @${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.'
           });


### PR DESCRIPTION
### What
Add @ symbol to username in bump version workflow.

### Why
So that the triggering user is mentioned on the opened PR and notified of it being opened.