### PR TITLE
Add release instructions to the bump version PR

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -37,5 +37,5 @@ jobs:
             repo: context.repo.repo,
             head: 'release/v${{ inputs.version }}',
             base: 'main',
-            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.\n\nThen merge this PR when ready to release the version.\n\nAfter merging, create a release for this version by going here: https://github.com/${{ github.repository }}/releases/new??tag=v${{ inputs.version }}&title=${{ inputs.version }}. Creating the release will trigger the publish.'
+            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.\n\nThen merge this PR when ready to release the version.\n\nAfter merging, create a release for this version by going here: https://github.com/${{ github.repository }}/releases/new?tag=v${{ inputs.version }}&title=${{ inputs.version }}. Creating the release will trigger the publish.'
           });

--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -37,5 +37,5 @@ jobs:
             repo: context.repo.repo,
             head: 'release/v${{ inputs.version }}',
             base: 'main',
-            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.'
+            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.\n\nThen merge this PR when ready to release the version.\n\nAfter merging, create a release for this version by going here: https://github.com/${{ github.repository }}/releases/new??tag=v${{ inputs.version }}&title=${{ inputs.version }}. Creating the release will trigger the publish.'
           });

--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -37,5 +37,5 @@ jobs:
             repo: context.repo.repo,
             head: 'release/v${{ inputs.version }}',
             base: 'main',
-            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.\n\nThen merge this PR when ready to release the version.\n\nAfter merging, create a release for this version by going here: https://github.com/${{ github.repository }}/releases/new?tag=v${{ inputs.version }}&title=${{ inputs.version }}. Creating the release will trigger the publish.'
+            body: '### What\nBump version to ${{ inputs.version }}, creating release branch.\n\n### Why\nTriggered by ${{ github.actor }}.\n\n### What is next\nCommit any changes to the `release/v${{ inputs.version }}` branch that are needed in this release.\n\nThen merge this PR when ready to release the version.\n\nAfter merging, create a release for this version by going to the link below. Creating the release will trigger the publish.\n\nhttps://github.com/${{ github.repository }}/releases/new?tag=v${{ inputs.version }}&title=${{ inputs.version }}'
           });


### PR DESCRIPTION
### What
Add release instructions to the PR that the bump version workflow opens.

### Why
To help people get to the next step.