### PR TITLE
Make runs-on input not required for publish dry run

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        required: true
+        required: false
         default: 'ubuntu-latest'
         type: string
       cargo-package-options:


### PR DESCRIPTION
### What
Make runs-on input not required for publish dry run.

### Why
So that repos do not have to specify the value. Even if there is a default value, the required flag forces it to be provided.