### PR TITLE
Rename publish job to publish-dry-run in dry run workflow

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
 
-  publish:
+  publish-dry-run:
     runs-on: ${{ inputs.runs-on }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What
Rename publish job to publish-dry-run in dry run workflow.

### Why
To make the job name less confusing.