### PR TITLE
Give repos more control over feature sets run during dry run

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -9,6 +9,7 @@ on:
         type: string
       cargo-hack-feature-options:
         required: false
+        default: '--feature-powerset'
         type: string
       cargo-package-options:
         required: false
@@ -53,7 +54,6 @@ jobs:
     # each crate are verified to compile.
     - run: >
         cargo hack
-        --feature-powerset
         ${{ inputs.cargo-hack-feature-options }}
         --ignore-private
         --config "source.crates-io.replace-with = 'vendored-sources'"


### PR DESCRIPTION
### What
Give repos more control over feature sets run during dry run.

### Why
Some repos need to turn off feature powerset for some builds.