### PR TITLE
Require publish-dry-run to complete on repos that wait on complete

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -17,6 +17,14 @@ on:
 
 jobs:
 
+  complete:
+    if: always()
+    needs: [publish-dry-run]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
+
   publish-dry-run:
     runs-on: ${{ inputs.runs-on }}
     steps:


### PR DESCRIPTION
### What
Add complete job to rust-publish-dry-run workflow.

### Why
Our repos wait on all complete jobs being finished before a pull request can merge. This requires that the publish-dry-run job finishes before allowing a bump verison pull request to merge.