### PR TITLE
Change link for rust-cache to its readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ workflows.
 
 [@stellar]: https://github.com/stellar
 
-[rust-cache]: ./rust-cache/action.yml
+[rust-cache]: ./rust-cache
 [rust-set-rust-version]: ./.github/workflows/rust-set-rust-version.yml
 [rust-bump-version]: ./.github/workflows/rust-bump-version.yml
 [rust-publish-dry-run]: ./.github/workflows/rust-publish-dry-run.yml


### PR DESCRIPTION
### What
Change the link in the readme for the rust-cache action so that it links to a page that shows the rust-cache readme.

### Why
The rust-cache readme has usage instructions. It is better to link a user to the usage instructions than it is to link them to the code.