### PR TITLE
Install sccache via binary

### DIFF
--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -22,7 +22,14 @@ runs:
         cargo-target-global-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-
         cargo-target-global-${{ github.workflow }}-${{ github.job }}-
   - shell: bash
-    run: cargo install --target-dir ~/.cargo/target --locked sccache
+    env:
+      SCCACHE_VERSION: v0.3.0
+      SCCACHE_TAR_GZ_SHA256: e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8
+    run: >
+      curl -sSL -O --output-dir /tmp https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz
+      sha256sum -c <(echo "$SCCACHE_TAR_GZ_SHA256  /tmp/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz")
+      tar xz -f /tmp/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz -C /usr/local/bin --strip-components=1 sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache
+      chmod +x /usr/local/bin/sccache
   - shell: bash
     run: |
       echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV


### PR DESCRIPTION
### What
Install sccache via binary instead of compile.

### Why
When creating pull requests for releases there is no initial cache, and it makes installing sccache expensive. We should just be installing it with binaries anyway rather than doing the long compile from source everytime we bump their version or when no cache is available.