### PR TITLE
Add an upload binaries step to publishing Rust projects

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -50,5 +50,6 @@ jobs:
         with:
           bin: ${{ inputs.bins }}
           target: ${{ matrix.target }}
+          ref: 'refs/tag/v0.1.2'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -2,6 +2,12 @@ name: Publish
 
 on:
   workflow_call:
+    inputs:
+      bins:
+        description: 'Comma-separated list of bins to upload to the release (empty if no bins)'
+        type: string
+        default: ''
+        required: false
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: true
@@ -18,3 +24,26 @@ jobs:
     - run: cargo workspaces publish --all --force '*' --from-git --yes
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload:
+    if: inputs.bins
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@57510bf386b3945b57963e73201cea60ca18dff4 # v1.9.1
+        with:
+          bin: ${{ inputs.bins }}
+          target: ${{ matrix.target }}

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -11,9 +11,9 @@ on:
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        description: 'GitHub token for uploading bins (required only if bins)'
-        required: false
+      # GITHUB_TOKEN:
+      #   description: 'GitHub token for uploading bins (required only if bins)'
+      #   required: false
 
 jobs:
 

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -11,9 +11,6 @@ on:
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: true
-      # GITHUB_TOKEN:
-      #   description: 'GitHub token for uploading bins (required only if bins)'
-      #   required: false
 
 jobs:
 

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -11,6 +11,9 @@ on:
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: true
+      GITHUB_TOKEN:
+        description: 'GitHub token for uploading bins (required only if bins)'
+        required: false
 
 jobs:
 
@@ -47,3 +50,5 @@ jobs:
         with:
           bin: ${{ inputs.bins }}
           target: ${{ matrix.target }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           bin: ${{ inputs.bins }}
           target: ${{ matrix.target }}
-          ref: 'refs/tag/v0.1.2'
+          ref: 'refs/tags/v0.1.2'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What
Add an upload binaries step to publishing Rust projects.

### Why
So that projects that have binaries can be stored in the GitHub release and used for installs instead of needing to install from source.

The main reason to add this is so that we can install soroban-cli into places that are inconvenient to do a build from source. For example, when installing soroban-cli into a repl.it, the build consumes so much disk space that it often fails to install.

I've added this process to the existing publish action because I think it will be beneficial if we lead into using this same process for any Rust project that has binaries. There might be some growing pains with that, if for example we have tools we only want to release on specific architectures, etc. I think we can tackle those problems when they arise rather than try to presolve for them.