### PR TITLE
Update cargo-set-rust-version

### DIFF
--- a/.github/workflows/rust-set-rust-version.yml
+++ b/.github/workflows/rust-set-rust-version.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.4.0 cargo-set-rust-version
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.0 cargo-set-rust-version
 
     # Update the rust-version in all workspace crates to the latest stable
     # version.


### PR DESCRIPTION
### What
Update cargo-set-rust-version.

### Why
To get a fix for repos like the soroban-cli that have a workspace with a package in the root manifest.