### PR TITLE
Remove unnecessary complete job

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -17,14 +17,6 @@ on:
 
 jobs:
 
-  complete:
-    if: always()
-    needs: [publish-dry-run]
-    runs-on: ubuntu-latest
-    steps:
-    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-      run: exit 1
-
   publish-dry-run:
     runs-on: ${{ inputs.runs-on }}
     steps:


### PR DESCRIPTION
### What
Remove unnecessary complete job.

### Why
It makes builds noisy in workflows that call it.