### PR TITLE
Add support for macOS, Windows to rust-cache

### DIFF
--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -24,20 +24,20 @@ runs:
   - shell: bash
     env:
       SCCACHE_VERSION: v0.3.0
-      SCCACHE_FILE_Linux: sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-      SCCACHE_FILE_SHA256_Linux: e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8
-      SCCACHE_DIR_Linux: sccache-v0.3.0-x86_64-unknown-linux-musl
-      SCCACHE_FILE_macOS: sccache-v0.3.0-x86_64-apple-darwin.tar.gz
-      SCCACHE_FILE_SHA256_macOS: 61c16fd36e32cdc923b66e4f95cb367494702f60f6d90659af1af84c3efb11eb
-      SCCACHE_DIR_macOS: sccache-v0.3.0-x86_64-apple-darwin
-      SCCACHE_FILE_Windows: sccache-v0.3.0-x86_64-pc-windows-msvc.tar.gz
-      SCCACHE_FILE_SHA256_Windows: f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be
-      SCCACHE_DIR_Windows: sccache-v0.3.0-x86_64-pc-windows-msvc
+      SCCACHE_FILE: >
+        ${{ (runner.os == 'Linux' && 'sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz')
+        || (runner.os == 'macOS' && 'sccache-v0.3.0-x86_64-apple-darwin.tar.gz')
+        || (runner.os == 'Windows' && 'sccache-v0.3.0-x86_64-pc-windows-msvc.tar.gz') }}
+      SCCACHE_FILE_SHA256: >
+        ${{ (runner.os == 'Linux' && 'e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8')
+        || (runner.os == 'macOS' && '61c16fd36e32cdc923b66e4f95cb367494702f60f6d90659af1af84c3efb11eb')
+        || (runner.os == 'Windows' && 'f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be') }}
+      SCCACHE_DIR: >
+        ${{ (runner.os == 'Linux' && 'sccache-v0.3.0-x86_64-unknown-linux-musl')
+        || (runner.os == 'macOS' && 'sccache-v0.3.0-x86_64-apple-darwin')
+        || (runner.os == 'Windows' && 'sccache-v0.3.0-x86_64-pc-windows-msvc') }}
+      SCCACHE_BIN_FILE: sccache${{ runner.os == 'Windows' && '.exe' || '' }}
     run: |
-      SCCACHE_FILE="$SCCACHE_FILE_${{ runner.os }}"
-      SCCACHE_FILE_SHA256="$SCCACHE_FILE_SHA256_${{ runner.os }}"
-      SCCACHE_DIR="$SCCACHE_DIR_${{ runner.os }}"
-      SCCACHE_BIN_FILE="sccache${{ runner.os == 'Windows' && '.exe' || '' }}"
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
       $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -37,7 +37,7 @@ runs:
       SCCACHE_FILE="$SCCACHE_FILE_${{ runner.os }}"
       SCCACHE_FILE_SHA256="$SCCACHE_FILE_SHA256_${{ runner.os }}"
       SCCACHE_DIR="$SCCACHE_DIR_${{ runner.os }}"
-      SCCACHE_BIN_FILE="sccache${{ runner.os == 'Windows' && '.exe' }}"
+      SCCACHE_BIN_FILE="sccache${{ runner.os == 'Windows' && '.exe' || '' }}"
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
       $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -41,14 +41,11 @@ runs:
     run: |
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       $SHASUM -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
-      mkdir -p $HOME/.local/bin
-      echo "$HOME/.local/bin" >> $GITHUB_PATH
       tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/$SCCACHE_BIN_FILE
       chmod +x "$HOME/.local/bin/$SCCACHE_BIN_FILE"
   - shell: bash
     run: |
-      # echo 'RUSTC_WRAPPER=sccache${{ runner.os == 'Windows' && '.exe' || '' }}' >> $GITHUB_ENV
-      echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV
+      echo "RUSTC_WRAPPER=$HOME/.local/bin/sccache${{ runner.os == 'Windows' && '.exe' || '' }}" >> $GITHUB_ENV
       echo 'SCCACHE_CACHE_SIZE=9G' >> $GITHUB_ENV
   - uses: actions/cache@v3
     with:

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -24,23 +24,23 @@ runs:
   - shell: bash
     env:
       SCCACHE_VERSION: v0.3.0
-      SCCACHE_FILE: >
+      SCCACHE_FILE: |
         ${{ (runner.os == 'Linux' && 'sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz')
         || (runner.os == 'macOS' && 'sccache-v0.3.0-x86_64-apple-darwin.tar.gz')
         || (runner.os == 'Windows' && 'sccache-v0.3.0-x86_64-pc-windows-msvc.tar.gz') }}
-      SCCACHE_FILE_SHA256: >
+      SCCACHE_FILE_SHA256: |
         ${{ (runner.os == 'Linux' && 'e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8')
         || (runner.os == 'macOS' && '61c16fd36e32cdc923b66e4f95cb367494702f60f6d90659af1af84c3efb11eb')
         || (runner.os == 'Windows' && 'f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be') }}
-      SCCACHE_DIR: >
+      SCCACHE_DIR: |
         ${{ (runner.os == 'Linux' && 'sccache-v0.3.0-x86_64-unknown-linux-musl')
         || (runner.os == 'macOS' && 'sccache-v0.3.0-x86_64-apple-darwin')
         || (runner.os == 'Windows' && 'sccache-v0.3.0-x86_64-pc-windows-msvc') }}
       SCCACHE_BIN_FILE: sccache${{ runner.os == 'Windows' && '.exe' || '' }}
+      SHASUM: ${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}
     run: |
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
-      shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
-      $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
+      $SHASUM -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
       mkdir -p $HOME/.local/bin
       echo "$HOME/.local/bin" >> $GITHUB_PATH
       tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/$SCCACHE_BIN_FILE

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -31,8 +31,10 @@ runs:
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
       $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
-      tar xz -f /tmp/$SCCACHE_FILE -C /usr/local/bin --strip-components=1 $SCCACHE_DIR/sccache
-      chmod +x /usr/local/bin/sccache
+      mkdir -p $HOME/.local/bin
+      echo "$HOME/.local/bin" >> $GITHUB_PATH
+      tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/sccache
+      chmod +x "$HOME/.local/bin/sccache"
   - shell: bash
     run: |
       echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -24,10 +24,19 @@ runs:
   - shell: bash
     env:
       SCCACHE_VERSION: v0.3.0
-      SCCACHE_FILE: sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-      SCCACHE_FILE_SHA256: e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8
-      SCCACHE_DIR: sccache-v0.3.0-x86_64-unknown-linux-musl
+      SCCACHE_FILE_Linux: sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
+      SCCACHE_FILE_SHA256_Linux: e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8
+      SCCACHE_DIR_Linux: sccache-v0.3.0-x86_64-unknown-linux-musl
+      SCCACHE_FILE_macOS: sccache-v0.3.0-x86_64-apple-darwin.tar.gz
+      SCCACHE_FILE_SHA256_macOS: 61c16fd36e32cdc923b66e4f95cb367494702f60f6d90659af1af84c3efb11eb
+      SCCACHE_DIR_macOS: sccache-v0.3.0-x86_64-apple-darwin
+      SCCACHE_FILE_Windows: sccache-v0.3.0-x86_64-pc-windows-msvc.tar.gz
+      SCCACHE_FILE_SHA256_Windows: f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be
+      SCCACHE_DIR_Windows: sccache-v0.3.0-x86_64-pc-windows-msvc
     run: |
+      SCCACHE_FILE="$SCCACHE_FILE_${{ runner.os }}"
+      SCCACHE_FILE_SHA256="$SCCACHE_FILE_SHA256_${{ runner.os }}"
+      SCCACHE_DIR="$SCCACHE_DIR_${{ runner.os }}"
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
       $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -29,7 +29,8 @@ runs:
       SCCACHE_DIR: sccache-v0.3.0-x86_64-unknown-linux-musl
     run: |
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
-      sha256sum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
+      shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
+      $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
       tar xz -f /tmp/$SCCACHE_FILE -C /usr/local/bin --strip-components=1 $SCCACHE_DIR/sccache
       chmod +x /usr/local/bin/sccache
   - shell: bash

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -47,7 +47,8 @@ runs:
       chmod +x "$HOME/.local/bin/$SCCACHE_BIN_FILE"
   - shell: bash
     run: |
-      echo 'RUSTC_WRAPPER=sccache${{ runner.os == 'Windows' && '.exe' || '' }}' >> $GITHUB_ENV
+      # echo 'RUSTC_WRAPPER=sccache${{ runner.os == 'Windows' && '.exe' || '' }}' >> $GITHUB_ENV
+      echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV
       echo 'SCCACHE_CACHE_SIZE=9G' >> $GITHUB_ENV
   - uses: actions/cache@v3
     with:

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -47,7 +47,7 @@ runs:
       chmod +x "$HOME/.local/bin/$SCCACHE_BIN_FILE"
   - shell: bash
     run: |
-      echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV
+      echo 'RUSTC_WRAPPER=sccache${{ runner.os == 'Windows' && '.exe' || '' }}' >> $GITHUB_ENV
       echo 'SCCACHE_CACHE_SIZE=9G' >> $GITHUB_ENV
   - uses: actions/cache@v3
     with:

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -41,6 +41,7 @@ runs:
     run: |
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       $SHASUM -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
+      mkdir -p "$HOME/.local/bin"
       tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/$SCCACHE_BIN_FILE
       chmod +x "$HOME/.local/bin/$SCCACHE_BIN_FILE"
   - shell: bash

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -37,13 +37,14 @@ runs:
       SCCACHE_FILE="$SCCACHE_FILE_${{ runner.os }}"
       SCCACHE_FILE_SHA256="$SCCACHE_FILE_SHA256_${{ runner.os }}"
       SCCACHE_DIR="$SCCACHE_DIR_${{ runner.os }}"
+      SCCACHE_BIN_FILE="sccache${{ runner.os == 'Windows' && '.exe' }}"
       curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       shasum="${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}"
       $shasum -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
       mkdir -p $HOME/.local/bin
       echo "$HOME/.local/bin" >> $GITHUB_PATH
-      tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/sccache
-      chmod +x "$HOME/.local/bin/sccache"
+      tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/$SCCACHE_BIN_FILE
+      chmod +x "$HOME/.local/bin/$SCCACHE_BIN_FILE"
   - shell: bash
     run: |
       echo 'RUSTC_WRAPPER=sccache' >> $GITHUB_ENV

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -24,15 +24,15 @@ runs:
   - shell: bash
     env:
       SCCACHE_VERSION: v0.3.0
-      SCCACHE_FILE: |
+      SCCACHE_FILE: >-
         ${{ (runner.os == 'Linux' && 'sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz')
         || (runner.os == 'macOS' && 'sccache-v0.3.0-x86_64-apple-darwin.tar.gz')
         || (runner.os == 'Windows' && 'sccache-v0.3.0-x86_64-pc-windows-msvc.tar.gz') }}
-      SCCACHE_FILE_SHA256: |
+      SCCACHE_FILE_SHA256: >-
         ${{ (runner.os == 'Linux' && 'e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8')
         || (runner.os == 'macOS' && '61c16fd36e32cdc923b66e4f95cb367494702f60f6d90659af1af84c3efb11eb')
         || (runner.os == 'Windows' && 'f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be') }}
-      SCCACHE_DIR: |
+      SCCACHE_DIR: >-
         ${{ (runner.os == 'Linux' && 'sccache-v0.3.0-x86_64-unknown-linux-musl')
         || (runner.os == 'macOS' && 'sccache-v0.3.0-x86_64-apple-darwin')
         || (runner.os == 'Windows' && 'sccache-v0.3.0-x86_64-pc-windows-msvc') }}


### PR DESCRIPTION
### What
Use shasum on macOS to verify the sha256 of sccache, and install the appropriate versions of sccache for the different runners OSes.

### Why
macOS has shasum, not sha256sum. We install a binary sccache and so need to install the appropriate versions for the different operating systems.