### PR TITLE
Use stellar/binaries for binary installs

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -20,7 +20,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.2.35 cargo-workspaces
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-workspaces
+        version: 0.2.35
     - id: set-version
       continue-on-error: true
       run: |

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -23,7 +23,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-hack
+        version: 0.5.16
 
     # Vendor all the dependencies into the vendor/ folder. Temporarily remove
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -14,7 +14,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.2.35 cargo-workspaces
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-workspaces
+        version: 0.2.35
     - run: cargo workspaces publish --all --force '*' --from-git --yes
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust-set-rust-version.yml
+++ b/.github/workflows/rust-set-rust-version.yml
@@ -10,7 +10,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.0 cargo-set-rust-version
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-set-rust-version
+        version: 0.5.0
 
     # Update the rust-version in all workspace crates to the latest stable
     # version.


### PR DESCRIPTION
### What
Use stellar/binaries for binary installs.

### Why
Avoiding long (5m+) compile times in release processes.