### PR TITLE
Make publish dry run work with all platforms

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -15,9 +15,6 @@ on:
         required: false
         default: '--feature-powerset'
         type: string
-      cargo-package-options:
-        required: false
-        type: string
 
 jobs:
 
@@ -27,9 +24,14 @@ jobs:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
     steps:
     - uses: actions/checkout@v3
+
     - uses: stellar/actions/rust-cache@main
+
     - run: rustup update
     - run: rustup target add ${{ inputs.target }}
+    - if: inputs.target == 'aarch64-unknown-linux-gnu'
+      run: sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
     - uses: stellar/binaries@v12
       with:
         name: cargo-hack
@@ -69,4 +71,4 @@ jobs:
         --config "source.crates-io.replace-with = 'vendored-sources'"
         --config "source.vendored-sources.directory = 'vendor'"
         package
-        ${{ inputs.cargo-package-options }}
+        --target ${{ inputs.target }}

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -44,6 +44,7 @@ jobs:
         cp Cargo.toml Cargo.toml.bak
         sed -r '/git ?=/d' Cargo.toml.bak > Cargo.toml
         cargo vendor --versioned-dirs
+        rm Cargo.toml
         mv Cargo.toml.bak Cargo.toml
 
     # Package the crates that will be published. Verification is disabled because

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+      target:
+        required: false
+        default: 'x86_64-unknown-linux-gnu'
+        type: string
       cargo-hack-feature-options:
         required: false
         default: '--feature-powerset'
@@ -19,10 +23,13 @@ jobs:
 
   publish-dry-run:
     runs-on: ${{ inputs.runs-on }}
+    env:
+      CARGO_BUILD_TARGET: ${{ inputs.target }}
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
+    - run: rustup target add ${{ inputs.target }}
     - uses: stellar/binaries@v12
       with:
         name: cargo-hack

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -78,9 +78,3 @@ jobs:
         --config "source.vendored-sources.directory = 'vendor'"
         package
         --target ${{ inputs.target }}
-
-    - if: always()
-      run: git status
-    - if: always()
-      run: git diff --color --ws-error-highlight=old,new,context
-

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -41,6 +41,7 @@ jobs:
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git
     # repos. These will be removed when published.
     - run: |
+        sed --help
         sed -i.bak -r '/git ?=/d' Cargo.toml
         cargo vendor --versioned-dirs
         mv Cargo.toml.bak Cargo.toml

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -16,6 +16,10 @@ on:
         default: '--feature-powerset'
         type: string
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   publish-dry-run:

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -79,5 +79,9 @@ jobs:
         --target ${{ inputs.target }}
 
     - if: always()
+      run: git status
+    - if: always()
+      run: git diff --name-only
+    - if: always()
       run: git diff --color --word-diff-regex=.
 

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -25,6 +25,7 @@ jobs:
         shell: bash
     env:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -77,3 +77,6 @@ jobs:
         --config "source.vendored-sources.directory = 'vendor'"
         package
         --target ${{ inputs.target }}
+
+    - if: always()
+      run: git diff

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -52,7 +52,7 @@ jobs:
 
     # Package the crates that will be published. Verification is disabled because
     # we aren't ready to verify yet.
-    - run: cargo hack --ignore-private package --no-verify ${{ inputs.cargo-package-options }}
+    - run: cargo-hack hack --ignore-private package --no-verify ${{ inputs.cargo-package-options }}
 
     # Add each crate that was packaged to the vendor/ directory.
     - run: |
@@ -70,7 +70,7 @@ jobs:
     # the package command on the full feature powerset so that all features of
     # each crate are verified to compile.
     - run: >
-        cargo hack
+        cargo-hack hack
         ${{ inputs.cargo-hack-feature-options }}
         --ignore-private
         --config "source.crates-io.replace-with = 'vendored-sources'"

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -42,7 +42,8 @@ jobs:
     # repos. These will be removed when published.
     - run: |
         sed --help
-        sed -i.bak -r '/git ?=/d' Cargo.toml
+        cp Cargo.toml Cargo.toml.bak
+        sed -r '/git ?=/d' Cargo.toml.bak > Cargo.toml
         cargo vendor --versioned-dirs
         mv Cargo.toml.bak Cargo.toml
 

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -16,14 +16,13 @@ on:
         default: '--feature-powerset'
         type: string
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
 
   publish-dry-run:
     runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        shell: bash
     env:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
     steps:

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -81,7 +81,5 @@ jobs:
     - if: always()
       run: git status
     - if: always()
-      run: git diff --name-only
-    - if: always()
-      run: git diff --color --word-diff-regex=.
+      run: git diff --color --ws-error-highlight=old,new,context
 

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
     steps:
+    - run: git config --global core.autocrlf true
     - uses: actions/checkout@v3
 
     - uses: stellar/actions/rust-cache@main

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
     steps:
-    - run: git config --global core.autocrlf true
     - uses: actions/checkout@v3
 
     - uses: stellar/actions/rust-cache@main
@@ -80,4 +79,5 @@ jobs:
         --target ${{ inputs.target }}
 
     - if: always()
-      run: git diff
+      run: git diff --color --word-diff-regex=.
+

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -41,7 +41,6 @@ jobs:
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git
     # repos. These will be removed when published.
     - run: |
-        sed --help
         cp Cargo.toml Cargo.toml.bak
         sed -r '/git ?=/d' Cargo.toml.bak > Cargo.toml
         cargo vendor --versioned-dirs


### PR DESCRIPTION
### What
Make publish dry run work with all platforms.

### Why
So that we verify a release is ready and safe for all platforms before release.