### PR TITLE
Remove rev when we remove git repo

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -46,7 +46,7 @@ jobs:
     # repos. These will be removed when published.
     - run: |
         cp Cargo.toml Cargo.toml.bak
-        sed -r '/git ?=/d' Cargo.toml.bak > Cargo.toml
+        sed -r '/git|rev ?=/d' Cargo.toml.bak > Cargo.toml
         cargo vendor --versioned-dirs
         rm Cargo.toml
         mv Cargo.toml.bak Cargo.toml

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -46,7 +46,7 @@ jobs:
     # repos. These will be removed when published.
     - run: |
         cp Cargo.toml Cargo.toml.bak
-        sed -r '/git|rev ?=/d' Cargo.toml.bak > Cargo.toml
+        sed -r '/(git|rev) ?=/d' Cargo.toml.bak > Cargo.toml
         cargo vendor --versioned-dirs
         rm Cargo.toml
         mv Cargo.toml.bak Cargo.toml


### PR DESCRIPTION
Fixes the error seen here where the git repo is removed, but not the git revision - https://github.com/stellar/rs-soroban-env/actions/runs/3517668668/jobs/5895702845.