### PR TITLE
Use cargo-edit instead of cargo-workspaces for bump version

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -20,14 +20,14 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v13
       with:
-        name: cargo-workspaces
-        version: 0.2.35
+        name: cargo-edit
+        version: 0.11.6
     - id: set-version
       continue-on-error: true
       run: |
-        cargo workspaces version --all --force '*' --no-git-commit --yes custom ${{ inputs.version }}
+        cargo set-version ${{ inputs.version }}
     - name: Create Commit
       run: |
         git config --global user.name 'github-actions[bot]'


### PR DESCRIPTION
### What
Use cargo-edit instead of cargo-workspaces for bump version.

### Why
Cargo workspaces does not support workspaces that use workspace inheritance, while cargo edit's `cargo set-version` command does.