### PR TITLE
rust-publish-dry-run workflow should actually do `cargo publish --dry-run`

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -66,23 +66,16 @@ jobs:
           echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
         done
 
-    # Rerun the package command but with verification enabled this time. Tell
-    # cargo to use the local vendor/ directory as the source for all packages. Run
-    # the package command on the full feature powerset so that all features of
-    # each crate are verified to compile.
+    # Try a publish --dry-run the package. Tell cargo to use the local vendor/
+    # directory as the source for all packages. Run the package command on
+    # the full feature powerset so that all features of each crate are
+    # verified to compile.
     - run: >
         cargo-hack hack
         ${{ inputs.cargo-hack-feature-options }}
+        --all
         --ignore-private
         --config "source.crates-io.replace-with = 'vendored-sources'"
         --config "source.vendored-sources.directory = 'vendor'"
-        package
+        publish --dry-run --locked
         --target ${{ inputs.target }}
-
-    # Try a publish --dry-run for each public (i.e. published) crate
-    - run: >
-        public_crates=$(cargo workspaces list)
-        for ws in $public_crates
-        do
-          cargo publish --dry-run --locked --package $ws
-        done

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -78,3 +78,11 @@ jobs:
         --config "source.vendored-sources.directory = 'vendor'"
         package
         --target ${{ inputs.target }}
+
+    # Try a publish --dry-run for each public (i.e. published) crate
+    - run: >
+        public_crates=$(cargo workspaces list)
+        for ws in $public_crates
+        do
+          cargo publish --dry-run --locked --package $ws
+        done


### PR DESCRIPTION
Currently the one step the workflow doesn't do is `cargo publish --dry-run`. It should probably do what it says it does. 😂 

This would have caught https://github.com/stellar/soroban-tools/actions/runs/3631215259/jobs/6125551822 before making the release tag.