### PR TITLE
Make apt-get installs more resilient

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -34,7 +34,7 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ inputs.target }}
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
     - uses: stellar/binaries@v12
       with:


### PR DESCRIPTION
### What
Run apt-get update before apt-get install.

### Why
We're seeing failures which are likely to do with the apt-get repositories that are cached being out of date. It's common practice to run update before install.