### PR TITLE
Cache rust artifacts in small isolated cache entries

### DIFF
--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -58,3 +58,9 @@ runs:
     shell: bash
     run: |
       echo 'SCCACHE_GHA_CACHE_FROM=cargo-sccache-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-,cargo-sccache-${{ github.workflow }}-${{ github.job }}-' >> $GITHUB_ENV
+  - name: Set ACTIONS_CACHE_URL and ACTIONS_RUNTIME_TOKEN
+    uses: actions/github-script@v6
+    with:
+      script: |
+        core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -1,5 +1,10 @@
 name: 'Rust Cache'
 description: 'Cache rust dep and build artifacts'
+
+inputs:
+  size:
+    default: 9G
+
 runs:
   using: "composite"
   steps:
@@ -47,15 +52,9 @@ runs:
   - shell: bash
     run: |
       echo "RUSTC_WRAPPER=$HOME/.local/bin/sccache${{ runner.os == 'Windows' && '.exe' || '' }}" >> $GITHUB_ENV
-      echo 'SCCACHE_CACHE_SIZE=9G' >> $GITHUB_ENV
-  - uses: actions/cache@v3
-    with:
-      path: ~/.cache/sccache
-      key: |
-        cargo-sccache-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
-      restore-keys: |
-        cargo-sccache-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-
-        cargo-sccache-${{ github.workflow }}-${{ github.job }}-
-  - if: github.ref_protected
+      echo 'SCCACHE_CACHE_SIZE=${{ inputs.size }}' >> $GITHUB_ENV
+      echo 'SCCACHE_GHA_CACHE_TO=cargo-sccache-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}' >> $GITHUB_ENV
+  - if: '!github.ref_protected'
     shell: bash
-    run: rm -fr ~/.cache/sccache
+    run: |
+      echo 'SCCACHE_GHA_CACHE_FROM=cargo-sccache-${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-,cargo-sccache-${{ github.workflow }}-${{ github.job }}-' >> $GITHUB_ENV


### PR DESCRIPTION
### What
Cache rust build artifacts in small entries in the actions cache, instead of as one large cache at the end.

### Why
Make more efficient use of the cache. It is supposedly the "right way" to use sccache.