### PR TITLE
Add Publish Dry Run v2

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -6,6 +6,7 @@ on:
       crates:
         description: 'Space separated list of crate names in the order to be published.'
         required: true
+        type: string
       runs-on:
         required: false
         default: 'ubuntu-latest'

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -62,7 +62,7 @@ jobs:
         for name in ${{ inputs.crates }}
         do
           cargo package --package $name --no-verify
-          tar xvfz "target/package/${crate}.crate" -C vendor/
+          tar xvfz "target/package/${crate}-*.crate" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't
           # matter if it is empty.
           echo '{"files":{}}' > vendor/$name/.cargo-checksum.json

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -64,12 +64,10 @@ jobs:
           version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'") | .version')
           cargo package --package $name --no-verify
           path="target/package/${name}-${version}.crate"
-          echo $path
-          ls target/package
           tar xvfz "$path" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't
           # matter if it is empty.
-          echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
+          echo '{"files":{}}' > vendor/$name-$version/.cargo-checksum.json
         done
 
     # Rerun the package command but with verification enabled this time. Tell

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -61,8 +61,9 @@ jobs:
     - run: |
         for name in ${{ inputs.crates }}
         do
+          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'")' | .version')
           cargo package --package $name --no-verify
-          tar xvfz "target/package/${crate}-*.crate" -C vendor/
+          tar xvfz "target/package/${name}-${version}.crate" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't
           # matter if it is empty.
           echo '{"files":{}}' > vendor/$name/.cargo-checksum.json

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -61,7 +61,7 @@ jobs:
     - run: |
         for name in ${{ inputs.crates }}
         do
-          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'")' | .version')
+          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'")' | .version)
           cargo package --package $name --no-verify
           path="target/package/${name}-${version}.crate"
           echo $path

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -48,7 +48,8 @@ jobs:
     # Vendor all the dependencies into the vendor/ folder. Temporarily remove
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git
     # repos. These will be removed when published.
-    - run: |
+    - name: Vendor Dependencies
+      run: |
         cp Cargo.toml Cargo.toml.bak
         sed -r '/(git|rev) ?=/d' Cargo.toml.bak > Cargo.toml
         cargo vendor --versioned-dirs
@@ -58,7 +59,8 @@ jobs:
     # Package the crates that will be published. Verification is disabled
     # because we aren't ready to verify yet. Add each crate that was packaged to
     # the vendor/ directory.
-    - run: |
+    - name: Package Crates ${{ inputs.crates }}
+      run: |
         for name in ${{ inputs.crates }}
         do
           version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'") | .version')
@@ -78,7 +80,8 @@ jobs:
     # cargo to use the local vendor/ directory as the source for all packages. Run
     # the package command on the full feature powerset so that all features of
     # each crate are verified to compile.
-    - run: >
+    - name: Verify Crates with ${{ inputs.cargo-hack-feature-options }}
+      run: >
         cargo-hack hack
         ${{ inputs.cargo-hack-feature-options }}
         --ignore-private

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -61,7 +61,7 @@ jobs:
     - run: |
         for name in ${{ inputs.crates }}
         do
-          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'")' | .version)
+          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'") | .version')
           cargo package --package $name --no-verify
           path="target/package/${name}-${version}.crate"
           echo $path

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -62,7 +62,11 @@ jobs:
         for name in ${{ inputs.crates }}
         do
           version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'") | .version')
-          cargo package --package $name --no-verify
+          cargo package \
+            --no-verify \
+            --package $name \
+            --config "source.crates-io.replace-with = 'vendored-sources'" \
+            --config "source.vendored-sources.directory = 'vendor'"
           path="target/package/${name}-${version}.crate"
           tar xvfz "$path" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -61,7 +61,6 @@ jobs:
     - run: |
         for name in ${{ inputs.crates }}
         do
-          name=$(basename "$crate" .crate)
           cargo package --package $name --no-verify
           tar xvfz "$crate" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -63,7 +63,10 @@ jobs:
         do
           version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'")' | .version')
           cargo package --package $name --no-verify
-          tar xvfz "target/package/${name}-${version}.crate" -C vendor/
+          path="target/package/${name}-${version}.crate"
+          echo $path
+          ls target/package
+          tar xvfz "$path" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't
           # matter if it is empty.
           echo '{"files":{}}' > vendor/$name/.cargo-checksum.json

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -1,4 +1,4 @@
-name: Publish Dry Run
+name: Publish Dry Run v2
 
 on:
   workflow_call:

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -62,7 +62,7 @@ jobs:
         for name in ${{ inputs.crates }}
         do
           cargo package --package $name --no-verify
-          tar xvfz "$crate" -C vendor/
+          tar xvfz "target/package/${crate}.crate" -C vendor/
           # Crates in the vendor directory require a checksum file, but it doesn't
           # matter if it is empty.
           echo '{"files":{}}' > vendor/$name/.cargo-checksum.json

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -1,0 +1,82 @@
+name: Publish Dry Run
+
+on:
+  workflow_call:
+    inputs:
+      crates:
+        description: 'Space separated list of crate names in the order to be published.'
+        required: true
+      runs-on:
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+      target:
+        required: false
+        default: 'x86_64-unknown-linux-gnu'
+        type: string
+      cargo-hack-feature-options:
+        required: false
+        default: '--feature-powerset'
+        type: string
+
+jobs:
+
+  publish-dry-run:
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ inputs.target }}
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: stellar/actions/rust-cache@main
+
+    - run: rustup update
+    - run: rustup target add ${{ inputs.target }}
+    - if: inputs.target == 'aarch64-unknown-linux-gnu'
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-hack
+        version: 0.5.16
+
+    # Vendor all the dependencies into the vendor/ folder. Temporarily remove
+    # [patch.crates-io] entries in the workspace Cargo.toml that reference git
+    # repos. These will be removed when published.
+    - run: |
+        cp Cargo.toml Cargo.toml.bak
+        sed -r '/(git|rev) ?=/d' Cargo.toml.bak > Cargo.toml
+        cargo vendor --versioned-dirs
+        rm Cargo.toml
+        mv Cargo.toml.bak Cargo.toml
+
+    # Package the crates that will be published. Verification is disabled
+    # because we aren't ready to verify yet. Add each crate that was packaged to
+    # the vendor/ directory.
+    - run: |
+        for name in ${{ inputs.crates }}
+        do
+          name=$(basename "$crate" .crate)
+          cargo package --package $name --no-verify
+          tar xvfz "$crate" -C vendor/
+          # Crates in the vendor directory require a checksum file, but it doesn't
+          # matter if it is empty.
+          echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
+        done
+
+    # Rerun the package command but with verification enabled this time. Tell
+    # cargo to use the local vendor/ directory as the source for all packages. Run
+    # the package command on the full feature powerset so that all features of
+    # each crate are verified to compile.
+    - run: >
+        cargo-hack hack
+        ${{ inputs.cargo-hack-feature-options }}
+        --ignore-private
+        --config "source.crates-io.replace-with = 'vendored-sources'"
+        --config "source.vendored-sources.directory = 'vendor'"
+        package
+        --target ${{ inputs.target }}

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -1,3 +1,8 @@
+# WARNING: This publish dry run process will not work on repositories that have
+# a crate containing bin targets that are dependent on other crates in the
+# repository. Please use `rust-publish-dry-run-v2` for any repository containing
+# binaries.
+
 name: Publish Dry Run
 
 on:

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -2,6 +2,8 @@
 # a crate containing bin targets that are dependent on other crates in the
 # repository. Please use `rust-publish-dry-run-v2` for any repository containing
 # binaries.
+#
+# For more details, see https://github.com/rust-lang/cargo/issues/11181.
 
 name: Publish Dry Run
 

--- a/README-rust-release.md
+++ b/README-rust-release.md
@@ -23,8 +23,8 @@ The following workflows support the release process:
 | Name | Description |
 | ---- | ----------- |
 | [rust-bump-version] | Updates the version in Rust crates to a input version. |
-| [rust-publish-dry-run] | Run a package verification on all crates in a workspace in their published form. |
-| [rust-publish-dry-run-v2] | Run a package verification on all crates in a workspace in their published form. |
+| [rust-publish-dry-run] | Run a package verification on all crates in a workspace in their published form that automatically figures out the crate dependencies and order to publish (works only for repos without a binary). |
+| [rust-publish-dry-run-v2] | Run a package verification on all crates in a workspace in their published form that requires an explicit list of crates to publish (works with all repos). |
 | [rust-publish] | Publish all crates in a workspace. |
 
 [rust-bump-version]: ./rust-bump-version/workflow.yml

--- a/README-rust-release.md
+++ b/README-rust-release.md
@@ -24,10 +24,12 @@ The following workflows support the release process:
 | ---- | ----------- |
 | [rust-bump-version] | Updates the version in Rust crates to a input version. |
 | [rust-publish-dry-run] | Run a package verification on all crates in a workspace in their published form. |
+| [rust-publish-dry-run-v2] | Run a package verification on all crates in a workspace in their published form. |
 | [rust-publish] | Publish all crates in a workspace. |
 
 [rust-bump-version]: ./rust-bump-version/workflow.yml
 [rust-publish-dry-run]: ./rust-publish-dry-run/workflow.yml
+[rust-publish-dry-run-v2]: ./rust-publish-dry-run-v2/workflow.yml
 [rust-publish]: ./rust-publish/workflow.yml
 
 ## Release Types
@@ -86,10 +88,11 @@ release. This will probably involve:
  released that the crates are dependent on.
  - Update any docs.
 
-_CI will run the [rust-publish-dry-run] checks on `release/*` branches to verify
-that when the crates are published their publish will succeed. This means you
-might see errors on CI that didn't exist before. These errors need resolving. If
-you see any errors you don't understand, ask in [#lang-rust]._
+_CI will run the [rust-publish-dry-run] or [rust-publish-dry-run-v2] checks on
+`release/*` branches to verify that when the crates are published their publish
+will succeed. This means you might see errors on CI that didn't exist before.
+These errors need resolving. If you see any errors you don't understand, ask in
+[#lang-rust]._
 
 ## 3. Merge PR
 
@@ -101,8 +104,8 @@ the `main` branch.
 
 ## 4. Create Release on GitHub
 
-First check that the `publish-dry-run` CI jobs have succeeded for the commit to
-be released.
+First check that the `publish-dry-run` or `publish-dry-run-v2` CI jobs have
+succeeded for the commit to be released.
 
 Draft a new release on GitHub for the repository by clicking on the relevant
 release link in the description of the PR from step 2.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ workflows.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | [rust-bump-version] | Workflow | Updates the version in Rust crates to a input version. |
-| [rust-publish-dry-run] | Workflow | Run a package verification on all crates in a workspace in their published form. |
-| [rust-publish-dry-run-v2] | Workflow | Run a package verification on all crates in a workspace in their published form. |
+| [rust-publish-dry-run] | Run a package verification on all crates in a workspace in their published form that automatically figures out the crate dependencies and order to publish (works only for repos without a binary). |
+| [rust-publish-dry-run-v2] | Run a package verification on all crates in a workspace in their published form that requires an explicit list of crates to publish (works with all repos). |
 | [rust-publish] | Workflow | Publish all crates in a workspace. |
 
 ### Project Management

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ workflows.
 | ---- | ---- | ----------- |
 | [rust-bump-version] | Workflow | Updates the version in Rust crates to a input version. |
 | [rust-publish-dry-run] | Workflow | Run a package verification on all crates in a workspace in their published form. |
+| [rust-publish-dry-run-v2] | Workflow | Run a package verification on all crates in a workspace in their published form. |
 | [rust-publish] | Workflow | Publish all crates in a workspace. |
 
 ### Project Management
@@ -64,6 +65,7 @@ workflows.
 [rust-set-rust-version]: ./.github/workflows/rust-set-rust-version.yml
 [rust-bump-version]: ./.github/workflows/rust-bump-version.yml
 [rust-publish-dry-run]: ./.github/workflows/rust-publish-dry-run.yml
+[rust-publish-dry-run-v2]: ./.github/workflows/rust-publish-dry-run-v2.yml
 [rust-publish]: ./.github/workflows/rust-publish.yml
 [update-completed-sprint-on-issue-closed]: ./.github/workflows/update-completed-sprint-on-issue-closed.yml
 

--- a/rust-publish-dry-run-v2/workflow.yml
+++ b/rust-publish-dry-run-v2/workflow.yml
@@ -1,0 +1,1 @@
+../.github/workflows/rust-publish-dry-run-v2.yml


### PR DESCRIPTION
### What
Add Publish Dry Run v2 that publishes an explicit list of crates in an explicit order provided by inputs, rather than calculated using tooling.

### Why
The existing dry run script is dependent on cargo being able to package crates without talking to crates.io. However, cargo does talk to crates.io to verify crates when building a lock file for a package, which is something it does when packaging binaries. Because of this the existing dry run script only works for libraries and not binaries.

The existing dry run script doesn't need to be told what crates to publish or what order to publish them in. It relies on cargo figuring that out, and because cargo doesn't talk to crates.io, it doesn't matter that none of the crates are published yet.

For binary crates we can't rely on cargo to package a group of crates out-of-order, and we need to provide the order they will get built in.

The v2 dry run uses this seemingly less convenient approach, that is more reliable.

For more details about the different way that cargo behaves for binaries and libraries, see https://github.com/rust-lang/cargo/issues/11181.