### PR TITLE
Add action that checks git rev deps for orphan likeliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
 | ---- | ---- | ----------- |
 | [rust-cache] | Action | Caches dependencies, install artifacts, and build artifacts in Rust projects. |
 | [rust-set-rust-version] | Workflow | Updates the rust-version in Rust crates to the latest stable version. |
+| [rust-check-git-rev-deps] | Workflow | Check that git rev dependencies do not reference revisions likely to be orphaned. |
 
 #### Releasing / Publishing
 

--- a/rust-check-git-rev-deps/README.md
+++ b/rust-check-git-rev-deps/README.md
@@ -1,0 +1,18 @@
+# rust-check-git-rev-deps Action
+
+The rust-check-git-rev-deps action checks that `git` dependencies that are
+versioned by a commit sha are not referring to a commit that is likely to become
+orphaned.
+
+Commits are accepted by the check if they can be found in one of:
+- The history of the default branch of the repository.
+- The history of a tag of the repository.
+
+## Usage
+
+```yml
+jobs:
+  my_job:
+    steps:
+    - uses: stellar/actions/rust-check-git-rev-deps@main
+```

--- a/rust-check-git-rev-deps/action.yml
+++ b/rust-check-git-rev-deps/action.yml
@@ -1,0 +1,8 @@
+name: 'Rust Check Git Rev Deps'
+description: 'Check that git revision dependencies are unlikely to be orphaned'
+runs:
+  using: "composite"
+  steps:
+  - shell: bash
+    run: |
+      ./check.sh

--- a/rust-check-git-rev-deps/action.yml
+++ b/rust-check-git-rev-deps/action.yml
@@ -4,5 +4,4 @@ runs:
   using: "composite"
   steps:
   - shell: bash
-    run: |
-      ./check.sh
+    run: ${{ github.action_path }}/check.sh

--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -16,8 +16,8 @@ cargo metadata --format-version 1 --no-deps \
     git clone "$repo" "$temp"
     pushd "$temp"
     found=0
-    for tag in . $(git tag); do
-      git -c advice.detachedHead=false checkout "$tag"
+    for ref in . $(git tag); do
+      git -c advice.detachedHead=false checkout "$ref"
       branch="$(git describe --all)"
       echo -e "\033[1;33mChecking is in "$branch"\033[0m"
       if git merge-base --is-ancestor HEAD "$sha"; then

--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -18,13 +18,13 @@ cargo metadata --format-version 1 --no-deps \
     found=0
     for ref in . $(git tag); do
       git -c advice.detachedHead=false checkout "$ref"
-      branch="$(git describe --all)"
-      echo -e "\033[1;33mChecking is in "$branch"\033[0m"
+      desc="$(git describe --all)"
+      echo -e "\033[1;33mChecking is in "$desc"\033[0m"
       if git merge-base --is-ancestor HEAD "$sha"; then
-        echo -e "\033[1;32mCommit is in the history of $branch.\033[0m"
+        echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
         found=1
       else
-        echo -e "\033[1;31mCommit is NOT in the history of $branch.\033[0m"
+        echo -e "\033[1;31mCommit is NOT in the history of $desc.\033[0m"
       fi
     done
     if (( $found == 0 )); then

--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Get repo and sha's of all dependencies in the current cargo workspace that are
+# git references containing a revision/commit sha.
+cargo metadata --format-version 1 --no-deps \
+  | jq -r '[.packages[].dependencies] | flatten | [.[] | .source | select(. != null) | select(. | startswith("git+")) | select(. | contains("?rev=")) | sub("^git\\+"; "") | split("?rev=")] | unique | sort | .[] | @tsv' \
+  | while IFS=$'\t' read -r repo sha; do
+    # For each, clone the repo, checkout the default branch and tags, and check
+    # that the commit can be found in at least one of them.
+    temp=$(mktemp -d)
+    echo -e "\033[1;34mChecking "$repo" @ "$sha"\033[0m"
+    git clone "$repo" "$temp"
+    pushd "$temp"
+    found=0
+    for tag in . $(git tag); do
+      git -c advice.detachedHead=false checkout "$tag"
+      branch="$(git describe --all)"
+      echo -e "\033[1;33mChecking is in "$branch"\033[0m"
+      if git merge-base --is-ancestor HEAD "$sha"; then
+        echo -e "\033[1;32mCommit is in the history of $branch.\033[0m"
+        found=1
+      else
+        echo -e "\033[1;31mCommit is NOT in the history of $branch.\033[0m"
+      fi
+    done
+    if (( $found == 0 )); then
+      echo -e "\033[1;31mDependency revisions must reference a version of the dependency that is on the default branch, or a tag, so that they do not become orphaned.\033[0m"
+    fi
+    popd
+  done

--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -8,27 +8,34 @@ set -o nounset
 # git references containing a revision/commit sha.
 cargo metadata --format-version 1 --no-deps \
   | jq -r '[.packages[].dependencies] | flatten | [.[] | .source | select(. != null) | select(. | startswith("git+")) | select(. | contains("?rev=")) | sub("^git\\+"; "") | split("?rev=")] | unique | sort | .[] | @tsv' \
-  | while IFS=$'\t' read -r repo sha; do
-    # For each, clone the repo, checkout the default branch and tags, and check
-    # that the commit can be found in at least one of them.
-    temp=$(mktemp -d)
-    echo -e "\033[1;34mChecking "$repo" @ "$sha"\033[0m"
-    git clone "$repo" "$temp"
-    pushd "$temp"
-    found=0
-    for ref in . $(git tag); do
-      git -c advice.detachedHead=false checkout "$ref"
-      desc="$(git describe --all)"
-      echo -e "\033[1;33mChecking is in "$desc"\033[0m"
-      if git merge-base --is-ancestor "$sha" HEAD; then
-        echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
-        found=1
-      else
-        echo -e "Commit is NOT in the history of $desc."
+  | {
+    fails=0
+    while IFS=$'\t' read -r repo sha; do
+      # For each, clone the repo, checkout the default branch and tags, and check
+      # that the commit can be found in at least one of them.
+      temp=$(mktemp -d)
+      echo -e "\033[1;34mChecking "$repo" @ "$sha"\033[0m"
+      git clone "$repo" "$temp"
+      pushd "$temp"
+      found=0
+      for ref in . $(git tag); do
+        git -c advice.detachedHead=false checkout "$ref"
+        desc="$(git describe --all)"
+        echo -e "\033[1;33mChecking is in "$desc"\033[0m"
+        if git merge-base --is-ancestor "$sha" HEAD; then
+          echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
+          found=1
+        else
+          echo -e "Commit is NOT in the history of $desc."
+        fi
+      done
+      if (( $found == 0 )); then
+        fails=1
       fi
+      popd
     done
-    if (( $found == 0 )); then
+    if (( $fails > 0 )); then
       echo -e "\033[1;31mDependency revisions must reference a version of the dependency that is on the default branch, or a tag, so that they do not become orphaned.\033[0m"
+      exit 1
     fi
-    popd
-  done
+  }

--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -20,11 +20,11 @@ cargo metadata --format-version 1 --no-deps \
       git -c advice.detachedHead=false checkout "$ref"
       desc="$(git describe --all)"
       echo -e "\033[1;33mChecking is in "$desc"\033[0m"
-      if git merge-base --is-ancestor HEAD "$sha"; then
+      if git merge-base --is-ancestor "$sha" HEAD; then
         echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
         found=1
       else
-        echo -e "\033[1;31mCommit is NOT in the history of $desc.\033[0m"
+        echo -e "Commit is NOT in the history of $desc."
       fi
     done
     if (( $found == 0 )); then


### PR DESCRIPTION
### What
Add action that checks git rev deps for whether they are likely to be orphaned.

### Why
On a number of occassions we've accidentally committed a reference to a dependency that belongs to a commit on a pull request. The pull request was then closed, and while the commit lives forever in the Git repository, it is not seen by tools that do not fetch orphaned commits.

Close #55