### PR TITLE
Simplify output of rust-check-git-rev-deps action

### DIFF
--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -15,14 +15,12 @@ cargo metadata --format-version 1 --no-deps \
       # that the commit can be found in at least one of them.
       temp=$(mktemp -d)
       echo -e "\033[1;34mChecking "$repo" @ "$sha"\033[0m"
-      git clone "$repo" "$temp"
-      pushd "$temp"
+      git clone --quiet "$repo" "$temp"
+      pushd "$temp" > /dev/null
       found=0
-      for ref in . $(git tag); do
-        git -c advice.detachedHead=false checkout "$ref"
-        desc="$(git describe --all)"
-        echo -e "\033[1;33mChecking is in "$desc"\033[0m"
-        if git merge-base --is-ancestor "$sha" HEAD; then
+      for ref in HEAD $(git tag); do
+        desc="$(git describe --all "$ref")"
+        if git merge-base --is-ancestor "$sha" "$ref"; then
           echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
           found=1
         else
@@ -32,7 +30,7 @@ cargo metadata --format-version 1 --no-deps \
       if (( $found == 0 )); then
         fails=1
       fi
-      popd
+      popd > /dev/null
     done
     if (( $fails > 0 )); then
       echo -e "\033[1;31mDependency revisions must reference a version of the dependency that is on the default branch, or a tag, so that they do not become orphaned.\033[0m"


### PR DESCRIPTION
### What
Remove verbose git output and don't checkout each ref being checked.

### Example

```diff
@@ -1,137 +1,32 @@
 Checking https://github.com/stellar/rs-stellar-strkey @ e6ba45c60c16de28c7522586b80ed0150157df73
-Cloning into '/var/folders/75/wqcxsy716bq0qht_8jtvw85h0000gn/T/tmp.ZjHN6hJp'...
-remote: Enumerating objects: 204, done.
-remote: Counting objects: 100% (140/140), done.
-remote: Compressing objects: 100% (91/91), done.
-remote: Total 204 (delta 90), reused 72 (delta 44), pack-reused 64
-Receiving objects: 100% (204/204), 52.70 KiB | 2.03 MiB/s, done.
-Resolving deltas: 100% (102/102), done.
-/var/folders/75/wqcxsy716bq0qht_8jtvw85h0000gn/T/tmp.ZjHN6hJp ~/Code/rs-soroban-env
-Updated 0 paths from the index
-Checking is in heads/main
 Commit is in the history of heads/main.
-HEAD is now at 317f768 Fix release automation (#31)
-Checking is in tags/v0.0.1
 Commit is NOT in the history of tags/v0.0.1.
-Previous HEAD position was 317f768 Fix release automation (#31)
-HEAD is now at afeb669 Bump version to 0.0.2 (#36)
-Checking is in tags/v0.0.2
 Commit is NOT in the history of tags/v0.0.2.
-Previous HEAD position was afeb669 Bump version to 0.0.2 (#36)
-HEAD is now at d1b68fd Bump version to 0.0.6 (#42)
-Checking is in tags/v0.0.6
 Commit is NOT in the history of tags/v0.0.6.
-Previous HEAD position was d1b68fd Bump version to 0.0.6 (#42)
-HEAD is now at 6e9bb10 Bump version to 0.0.7 (#53)
-Checking is in tags/v0.0.7
 Commit is NOT in the history of tags/v0.0.7.
-~/Code/rs-soroban-env
 Checking https://github.com/stellar/rs-stellar-xdr @ 39904e09941046dab61e6e35fc89e31bf2dea1cd
-Cloning into '/var/folders/75/wqcxsy716bq0qht_8jtvw85h0000gn/T/tmp.CX6EHwk1'...
-remote: Enumerating objects: 1894, done.
-remote: Counting objects: 100% (1894/1894), done.
-remote: Compressing objects: 100% (683/683), done.
-remote: Total 1894 (delta 1140), reused 1812 (delta 1104), pack-reused 0
-Receiving objects: 100% (1894/1894), 2.17 MiB | 10.77 MiB/s, done.
-Resolving deltas: 100% (1140/1140), done.
-/var/folders/75/wqcxsy716bq0qht_8jtvw85h0000gn/T/tmp.CX6EHwk1 ~/Code/rs-soroban-env
-Updated 0 paths from the index
-Checking is in heads/main
 Commit is in the history of heads/main.
-HEAD is now at 4876e5e Regen to pick up `ContractCostType` changes (#290)
-Checking is in tags/quarkslab-rs-xdr
 Commit is NOT in the history of tags/quarkslab-rs-xdr.
-Previous HEAD position was 4876e5e Regen to pick up `ContractCostType` changes (#290)
-HEAD is now at a5ce1a4 Release 0.0.2
-Checking is in tags/stellar-xdr@0.0.2
 Commit is NOT in the history of tags/stellar-xdr@0.0.2.
-Previous HEAD position was a5ce1a4 Release 0.0.2
-HEAD is now at 28a28dc Add docs.rs meta (#128)
-Checking is in tags/v0.0.1
 Commit is NOT in the history of tags/v0.0.1.
-Previous HEAD position was 28a28dc Add docs.rs meta (#128)
-HEAD is now at ef313b8 Make the default xdr decode stream base64 (#216)
-Checking is in tags/v0.0.10
 Commit is NOT in the history of tags/v0.0.10.
-Previous HEAD position was ef313b8 Make the default xdr decode stream base64 (#216)
-HEAD is now at dbf2aba Bump version to 0.0.11 (#219)
-Checking is in tags/v0.0.11
 Commit is NOT in the history of tags/v0.0.11.
-Previous HEAD position was dbf2aba Bump version to 0.0.11 (#219)
-HEAD is now at 154e07e Bump version to 0.0.12 (#225)
-Checking is in tags/v0.0.12
 Commit is NOT in the history of tags/v0.0.12.
-Previous HEAD position was 154e07e Bump version to 0.0.12 (#225)
-HEAD is now at bd9deaf Bump version to 0.0.13 (#233)
-Checking is in tags/v0.0.13
 Commit is NOT in the history of tags/v0.0.13.
-Previous HEAD position was bd9deaf Bump version to 0.0.13 (#233)
-HEAD is now at 55f47d3 Bump version to 0.0.14 (#236)
-Checking is in tags/v0.0.14
 Commit is NOT in the history of tags/v0.0.14.
-Previous HEAD position was 55f47d3 Bump version to 0.0.14 (#236)
-HEAD is now at 4655b63 Bump version to 0.0.15 (#241)
-Checking is in tags/v0.0.15
 Commit is NOT in the history of tags/v0.0.15.
-Previous HEAD position was 4655b63 Bump version to 0.0.15 (#241)
-HEAD is now at 53e1a9c Bump version to 0.0.16 (#256)
-Checking is in tags/v0.0.16
 Commit is NOT in the history of tags/v0.0.16.
-Previous HEAD position was 53e1a9c Bump version to 0.0.16 (#256)
-HEAD is now at 0f16673 Bump version to 0.0.17 (#280)
-Checking is in tags/v0.0.17
 Commit is NOT in the history of tags/v0.0.17.
-Previous HEAD position was 0f16673 Bump version to 0.0.17 (#280)
-HEAD is now at fee9a43 Bump version to 0.0.2 (#153)
-Checking is in tags/v0.0.2
 Commit is NOT in the history of tags/v0.0.2.
-Previous HEAD position was fee9a43 Bump version to 0.0.2 (#153)
-HEAD is now at 5cca712 Bump version to 0.0.6 (#180)
-Checking is in tags/v0.0.6
 Commit is NOT in the history of tags/v0.0.6.
-Previous HEAD position was 5cca712 Bump version to 0.0.6 (#180)
-HEAD is now at e88f9fa Bump version to 0.0.7 (#184)
-Checking is in tags/v0.0.7
 Commit is NOT in the history of tags/v0.0.7.
-Previous HEAD position was e88f9fa Bump version to 0.0.7 (#184)
-HEAD is now at 2a5bd49 Run publish dry run on main (#207)
-Checking is in tags/v0.0.8
 Commit is NOT in the history of tags/v0.0.8.
-Previous HEAD position was 2a5bd49 Run publish dry run on main (#207)
-HEAD is now at 1309e3d Bump version to 0.0.9 (#211)
-Checking is in tags/v0.0.9
 Commit is NOT in the history of tags/v0.0.9.
-~/Code/rs-soroban-env
 Checking https://github.com/stellar/wasmi @ 284c963ba080703061797e2a3cba0853edee0dd4
-Cloning into '/var/folders/75/wqcxsy716bq0qht_8jtvw85h0000gn/T/tmp.PSPBx8zQ'...
-remote: Enumerating objects: 5751, done.
-remote: Counting objects: 100% (5751/5751), done.
-remote: Compressing objects: 100% (2156/2156), done.
-remote: Total 5751 (delta 3563), reused 5553 (delta 3475), pack-reused 0
-Receiving objects: 100% (5751/5751), 3.87 MiB | 18.25 MiB/s, done.
-Resolving deltas: 100% (3563/3563), done.
-/var/folders/75/wqcxsy716bq0qht_8jtvw85h0000gn/T/tmp.PSPBx8zQ ~/Code/rs-soroban-env
-Updated 0 paths from the index
-Checking is in tags/v0.16.0-soroban2
 Commit is NOT in the history of tags/v0.16.0-soroban2.
-HEAD is now at 7b1f235 compensate for renaming in bin
-Checking is in tags/v0.11.0-soroban
 Commit is NOT in the history of tags/v0.11.0-soroban.
-Previous HEAD position was 7b1f235 compensate for renaming in bin
-HEAD is now at 349dd9a Bump version to 0.16.0-soroban0 (#6)
-Checking is in tags/v0.16.0-soroban0
 Commit is NOT in the history of tags/v0.16.0-soroban0.
-Previous HEAD position was 349dd9a Bump version to 0.16.0-soroban0 (#6)
-HEAD is now at d1ec003 Bump version to 0.16.0-soroban1 (#8)
-Checking is in tags/v0.16.0-soroban1
 Commit is NOT in the history of tags/v0.16.0-soroban1.
-Previous HEAD position was d1ec003 Bump version to 0.16.0-soroban1 (#8)
-HEAD is now at 862b32f Bump version to 0.16.0-soroban2 (#11)
-Checking is in tags/v0.16.0-soroban2
 Commit is NOT in the history of tags/v0.16.0-soroban2.
-Previous HEAD position was 862b32f Bump version to 0.16.0-soroban2 (#11)
-HEAD is now at 3dc639f Unfork all crates except for `wasmi` (#16)
-Checking is in tags/v0.30.0-soroban0
 Commit is NOT in the history of tags/v0.30.0-soroban0.
-~/Code/rs-soroban-env
 Dependency revisions must reference a version of the dependency that is on the default branch, or a tag, so that they do not become orphaned.
```

### Why
Checking out the refs is unnecessary as we can search for ancestors in history without changing the working directory.

Also, the pushd and git commands create some noise which is unnecessary, and not useful, especially in CI.

Succinct output makes it much easier to understand what is wrong when the check fails.

Follow up to #55