### PR TITLE
Reduce noisy warning-like messages in rust git rev action

### DIFF
--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -18,13 +18,17 @@ cargo metadata --format-version 1 --no-deps \
       git clone --quiet "$repo" "$temp"
       pushd "$temp" > /dev/null
       found=0
-      for ref in HEAD $(git tag); do
-        desc="$(git describe --all "$ref")"
-        if git merge-base --is-ancestor "$sha" "$ref"; then
-          echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
-          found=1
-        fi
-      done
+      if git fetch --quiet origin "$sha"; then
+        for ref in HEAD $(git tag); do
+          desc="$(git describe --all "$ref")"
+          if git merge-base --is-ancestor "$sha" "$ref"; then
+            echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
+            found=1
+          fi
+        done
+      else
+        echo -e "Commit NOT found in repository at all"
+      fi
       if (( $found == 0 )); then
         fails=1
         echo -e "Commit NOT found in the history of the default branch, or any tag."

--- a/rust-check-git-rev-deps/check.sh
+++ b/rust-check-git-rev-deps/check.sh
@@ -23,12 +23,11 @@ cargo metadata --format-version 1 --no-deps \
         if git merge-base --is-ancestor "$sha" "$ref"; then
           echo -e "\033[1;32mCommit is in the history of $desc.\033[0m"
           found=1
-        else
-          echo -e "Commit is NOT in the history of $desc."
         fi
       done
       if (( $found == 0 )); then
         fails=1
+        echo -e "Commit NOT found in the history of the default branch, or any tag."
       fi
       popd > /dev/null
     done


### PR DESCRIPTION
### What
Don't output a warning when a branch/tag doesn't contain the commit. Only output the message if no branches/tags are found that contain the commit.

And fetch the commit before testing it.

### Why
The message reads like a warning, and so it sounds like something is wrong when it is really informational.

If we fetch the commit first we can signal when a commit is entirely missing and that makes following error messages less confusing when it happens.

cc @graydon