### PR TITLE
Fix publish dry run for crates with no deps

### DIFF
--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -48,6 +48,11 @@ jobs:
         name: cargo-hack
         version: 0.5.16
 
+    # Create the vendor directory because it'll only be created in the next step
+    # if the crate has dependencies, but it's needed for the latter steps in all
+    # cases.
+    - run: mkdir -P vendor
+
     # Vendor all the dependencies into the vendor/ folder. Temporarily remove
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git
     # repos. These will be removed when published.

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -51,7 +51,7 @@ jobs:
     # Create the vendor directory because it'll only be created in the next step
     # if the crate has dependencies, but it's needed for the latter steps in all
     # cases.
-    - run: mkdir -P vendor
+    - run: mkdir -p vendor
 
     # Vendor all the dependencies into the vendor/ folder. Temporarily remove
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git


### PR DESCRIPTION
### What
Create vendor directory manually.

### Why
It'll only be created in the existing flow if a crate has dependencies, but it is needed in later steps of the flow in all cases. This is causing publish dry run to fail for crates with no deps because the vendor directory doesn't exist.