### PR TITLE
Update cargo-hack

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -40,10 +40,10 @@ jobs:
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v18
       with:
         name: cargo-hack
-        version: 0.5.16
+        version: 0.5.28
 
     # Vendor all the dependencies into the vendor/ folder. Temporarily remove
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -43,10 +43,10 @@ jobs:
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v18
       with:
         name: cargo-hack
-        version: 0.5.16
+        version: 0.5.28
 
     # Create the vendor directory because it'll only be created in the next step
     # if the crate has dependencies, but it's needed for the latter steps in all


### PR DESCRIPTION
### What
Update cargo-hack

### Why
Some of our Rust workspaces have started using workspace inheritance where fields can be defined in the virtual workspace Cargo.toml and then referenced from packages. Cargo-hack didn't support workspace inheritance for some fields (e.g. `rust-version`) in the version of cargo-hack currently in use, but it has been updated to support them in the version being changed to in this PR.