### PR TITLE
Update make prior to dry-runs on macOS.

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      RUST_BACKTRACE: 1
     steps:
     - uses: actions/checkout@v4
     - uses: stellar/actions/rust-cache@main
@@ -37,12 +38,12 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ inputs.target }}
 
-    - if: inputs.target == 'aarch64-unknown-linux-gnu'
+    - name: Install add'l compilers (Linux arm64 only)
+      if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-    # On macOS targets, update make to the latest version of GNU Make
-    - if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
-      name: Update GNU Make (macOS only)
+    - name: Update GNU Make (macOS only)
+      if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
       run: |
         brew update && brew install make
         export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -45,8 +45,11 @@ jobs:
     - name: Update GNU Make (macOS only)
       if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
       run: |
+        which make
+        make --version
         brew update && brew install make
         export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+        which make
         make --version
 
     - uses: stellar/binaries@v18
@@ -91,7 +94,7 @@ jobs:
     # each crate are verified to compile.
     - name: Verify Crates with ${{ inputs.cargo-hack-feature-options }}
       run: >
-        cargo-hack hack
+        make --version && cargo-hack hack
         ${{ inputs.cargo-hack-feature-options }}
         --ignore-private
         --config "source.crates-io.replace-with = 'vendored-sources'"

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -36,16 +36,22 @@ jobs:
 
     - run: rustup update
     - run: rustup target add ${{ inputs.target }}
+
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+    # On macOS targets, update make to the latest version of GNU Make
     - if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
+      name: Update GNU Make (macOS)
       run: |
         which make
         make --version
         brew update && brew install make
-        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
-        mv /usr/local/opt/make/libexec/gnubin/gmake /usr/bin/make
+        # export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+        # mv /usr/local/opt/make/libexec/gnubin/make /usr/bin/make
+        alias make=gmake
         make --version
+        which make
 
     - uses: stellar/binaries@v18
       with:

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -33,6 +33,7 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
     - uses: actions/checkout@v4
+
     - uses: stellar/actions/rust-cache@main
 
     - run: rustup update
@@ -91,9 +92,9 @@ jobs:
     - name: Verify Crates with ${{ inputs.cargo-hack-feature-options }}
       run: >
         cargo-hack hack
-          ${{ inputs.cargo-hack-feature-options }}
-          --ignore-private
-          --config "source.crates-io.replace-with = 'vendored-sources'"
-          --config "source.vendored-sources.directory = 'vendor'"
-          package
-          --target ${{ inputs.target }}
+        ${{ inputs.cargo-hack-feature-options }}
+        --ignore-private
+        --config "source.crates-io.replace-with = 'vendored-sources'"
+        --config "source.vendored-sources.directory = 'vendor'"
+        package
+        --target ${{ inputs.target }}

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -48,9 +48,7 @@ jobs:
         which make
         make --version
         brew update && brew install make
-        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
-        which make
-        make --version
+        echo "/usr/local/opt/make/libexec/gnubin/" >> $GITHUB_PATH
 
     - uses: stellar/binaries@v18
       with:

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -43,6 +43,8 @@ jobs:
       if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
+    # macOS comes with an old version of `make` that causes issues when building
+    # some projects
     - name: Update GNU Make (macOS only)
       if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
       run: |

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -40,7 +40,12 @@ jobs:
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
-      run: brew update && brew install make
+      run: |
+        which make
+        make --version
+        brew update && brew install make
+        make --version
+
     - uses: stellar/binaries@v18
       with:
         name: cargo-hack

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -47,9 +47,9 @@ jobs:
         which make
         make --version
         brew update && brew install make
-        # export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+        ls /usr/local/opt/make/libexec/gnubin/make
         # mv /usr/local/opt/make/libexec/gnubin/make /usr/bin/make
-        alias make=gmake
         make --version
         which make
 

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -94,7 +94,9 @@ jobs:
     # each crate are verified to compile.
     - name: Verify Crates with ${{ inputs.cargo-hack-feature-options }}
       run: >
-        make --version && cargo-hack hack
+        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH" &&
+        make --version &&
+        cargo-hack hack
         ${{ inputs.cargo-hack-feature-options }}
         --ignore-private
         --config "source.crates-io.replace-with = 'vendored-sources'"

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -47,10 +47,9 @@ jobs:
         which make
         make --version
         brew update && brew install make
-        ls /usr/local/opt/make/libexec/gnubin/
-        mv /usr/local/opt/make/libexec/gnubin/make /usr/bin/make
-        make --version
+        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
         which make
+        make --version
 
     - uses: stellar/binaries@v18
       with:

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -45,8 +45,6 @@ jobs:
     - name: Update GNU Make (macOS only)
       if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
       run: |
-        which make
-        make --version
         brew update && brew install make
         echo "/usr/local/opt/make/libexec/gnubin/" >> $GITHUB_PATH
 
@@ -92,12 +90,10 @@ jobs:
     # each crate are verified to compile.
     - name: Verify Crates with ${{ inputs.cargo-hack-feature-options }}
       run: >
-        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH" &&
-        make --version &&
         cargo-hack hack
-        ${{ inputs.cargo-hack-feature-options }}
-        --ignore-private
-        --config "source.crates-io.replace-with = 'vendored-sources'"
-        --config "source.vendored-sources.directory = 'vendor'"
-        package
-        --target ${{ inputs.target }}
+          ${{ inputs.cargo-hack-feature-options }}
+          --ignore-private
+          --config "source.crates-io.replace-with = 'vendored-sources'"
+          --config "source.vendored-sources.directory = 'vendor'"
+          package
+          --target ${{ inputs.target }}

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -44,11 +44,8 @@ jobs:
     - if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
       name: Update GNU Make (macOS only)
       run: |
-        which make
-        make --version
         brew update && brew install make
         export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
-        which make
         make --version
 
     - uses: stellar/binaries@v18

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -46,7 +46,7 @@ jobs:
       if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
       run: |
         brew update && brew install make
-        echo "/usr/local/opt/make/libexec/gnubin/" >> $GITHUB_PATH
+        echo "$(brew --prefix)/opt/make/libexec/gnubin/" >> $GITHUB_PATH
 
     - uses: stellar/binaries@v18
       with:

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -39,7 +39,8 @@ jobs:
     - run: rustup target add ${{ inputs.target }}
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
+    - if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
+      run: brew update && brew install make
     - uses: stellar/binaries@v18
       with:
         name: cargo-hack

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -31,8 +31,7 @@ jobs:
       CARGO_BUILD_TARGET: ${{ inputs.target }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
     steps:
-    - uses: actions/checkout@v3
-
+    - uses: actions/checkout@v4
     - uses: stellar/actions/rust-cache@main
 
     - run: rustup update
@@ -44,6 +43,8 @@ jobs:
         which make
         make --version
         brew update && brew install make
+        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+        mv /usr/local/opt/make/libexec/gnubin/gmake /usr/bin/make
         make --version
 
     - uses: stellar/binaries@v18

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -42,14 +42,13 @@ jobs:
 
     # On macOS targets, update make to the latest version of GNU Make
     - if: inputs.target == 'x86_64-apple-darwin' || inputs.target == 'aarch64-apple-darwin'
-      name: Update GNU Make (macOS)
+      name: Update GNU Make (macOS only)
       run: |
         which make
         make --version
         brew update && brew install make
-        export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
-        ls /usr/local/opt/make/libexec/gnubin/make
-        # mv /usr/local/opt/make/libexec/gnubin/make /usr/bin/make
+        ls /usr/local/opt/make/libexec/gnubin/
+        mv /usr/local/opt/make/libexec/gnubin/make /usr/bin/make
         make --version
         which make
 


### PR DESCRIPTION
Outdated versions of `make` cause problems when building certain binaries ([like soroban-cli](https://github.com/stellar/soroban-cli/actions/runs/7994869579/job/21833922140)).

This also enables debugging on failures via `RUST_BACKTRACE`.