### PR TITLE
Fix version look up in publish dry run to ignore deps

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         for name in ${{ inputs.crates }}
         do
-          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'") | .version')
+          version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="'$name'") | .version')
           cargo package \
             --no-verify \
             --package $name \


### PR DESCRIPTION
### What
Change version lookup in publish dry run v2 workflow to ignore deps when looking up versions of crates that are local to the repo.

### Why
Without constraining the version lookup to the crates in the current repo the lookup may return multiple versions if a crate has previously lived in another repo or if a crate in this repo is dependent on a previous version of a crate that is published to crates.io.