### PR TITLE
Update binaries across all workflows

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - uses: stellar/binaries@v13
+    - uses: stellar/binaries@v21
       with:
         name: cargo-edit
         version: 0.11.6

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -40,7 +40,7 @@ jobs:
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-    - uses: stellar/binaries@v18
+    - uses: stellar/binaries@v21
       with:
         name: cargo-hack
         version: 0.5.28

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -43,7 +43,7 @@ jobs:
     - if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-    - uses: stellar/binaries@v18
+    - uses: stellar/binaries@v21
       with:
         name: cargo-hack
         version: 0.5.28

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v21
       with:
         name: cargo-workspaces
         version: 0.2.35

--- a/.github/workflows/rust-set-rust-version.yml
+++ b/.github/workflows/rust-set-rust-version.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - uses: stellar/binaries@v12
+    - uses: stellar/binaries@v21
       with:
         name: cargo-set-rust-version
         version: 0.5.0


### PR DESCRIPTION
### What
Update binaries across all workflows.

### Why
The latest version of the binaries has binaries for ARM64 runners, and macos runners are primarily ARM64 on GitHub now.