### PR TITLE
Make publish-dry-run-v2 work without a list of crates and deprecate v1

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -103,18 +103,18 @@ jobs:
           );
           let crates = crates_str.split("\n");
 
-          // Get cargo metadata.
-          let metadata_str = "";
+          // Get list of crates that need publishing, but out of order.
+          let crates_need_publish_str = "";
           await exec.exec(
-            "cargo", [ "metadata", "--format-version=1", "--no-deps" ],
-            { listeners: { stdout: (buf) => { metadata_str += buf.toString(); } } },
+            "cargo", [ "workspaces", "list" ],
+            { listeners: { stdout: (buf) => { crates_need_publish_str += buf.toString(); } } },
           );
-          let metadata = JSON.parse(metadata_str);
+          let crates_need_publish = crates_need_publish_str.split("\n");
 
           // Filter the crates to those that publish.
-          let crates_that_publish = crates.filter((c) => metadata.packages.some((p) => p.name == c && p.publish !== []));
+          let crates_to_publish = crates.filter((c) => crates_to_publish.includes(c));
 
-          return crates_that_publish.join(" ");
+          return crates_to_publish.join(" ");
         result-encoding: string
     - name: List of Crates
       run: echo "${{steps.crates.outputs.result}}"

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -89,16 +89,26 @@ jobs:
     # If a list of crates weren't provided, prepare a list by asking
     # cargo-workspaces for the order it would publish the crates in, and filter
     # the list of returned crates by crates that are marked for publishing.
+    # '); cargo metadata --format-version 1 --no-deps | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' | grep -w -q $name && echo $name'');
     - name: Prepare List of Crates Ordered by Publish-Order
-      if: inputs.crates == ''
-      run: echo "CRATES=\""${$(cargo workspaces exec --no-bail sh -c 'name=$(basename $(pwd)); cargo metadata --format-version 1 --no-deps | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' | grep -w -q $name && echo $name')//$'\n'/ }\"" >> $GITHUB_ENV
+      run: echo "CRATES=\""${$()//$'\n'/ }\"" >> $GITHUB_ENV
+    - uses: actions/github-script@v7
+      id: crates
+      with:
+        script: |
+          const exec = require("@actions/exec");
+          let crates = await exec.exec("cargo workspaces exec --no-bail sh -c 'basename $(pwd)'");
+          return crates;
+        result-encoding: string
+    - name: List of Crates
+      run: echo "${{steps.crates.outputs.result}}"
 
     # Package the crates that will be published. Verification is disabled
     # because we aren't ready to verify yet. Add each crate that was packaged to
     # the vendor/ directory.
-    - name: Package Crates ${{ inputs.crates }}
+    - name: Package Crates ${{ steps.crates.outputs.result }}
       run: |
-        for name in ${{ inputs.crates }}
+        for name in ${{ steps.crates.outputs.result }}
         do
           version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="'$name'") | .version')
           cargo package \

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -108,7 +108,7 @@ jobs:
             ],
             {
               listeners: {
-                stdout: (data: Buffer) => { crates += data.toString(); },
+                stdout: (data) => { crates += data.toString(); },
               },
             },
           );

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -95,14 +95,26 @@ jobs:
       id: crates
       with:
         script: |
-          let crates_list = "";
+          // Get list of crates in publish order.
+          let crates_str = "";
           await exec.exec(
-            "cargo",
-            [ "workspaces", "exec", "--no-bail", "sh", "-c", "basename $(pwd)" ],
-            { listeners: { stdout: (buf) => { crates_list += buf.toString(); } } },
+            "cargo", [ "workspaces", "exec", "--no-bail", "sh", "-c", "basename $(pwd)" ],
+            { listeners: { stdout: (buf) => { crates_str += buf.toString(); } } },
           );
-          let crates = crates_list.split("\n");
-          return crates.join(" ");
+          let crates = crates_str.split("\n");
+
+          // Get cargo metadata.
+          let metadata_str = "";
+          await exec.exec(
+            "cargo", [ "metadata", "--format-version=1", "--no-deps" ],
+            { listeners: { stdout: (buf) => { metadata_str += buf.toString(); } } },
+          );
+          let metadata = JSON.parse(metadata_str);
+
+          // Filter the crates to those that publish.
+          let crates_that_publish = crates.filter((c) => metadata.packages.find((p) => p.name == c).publish !== []);
+
+          return crates_that_publish.join(" ");
         result-encoding: string
     - name: List of Crates
       run: echo "${{steps.crates.outputs.result}}"

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Prepare List of Crates Ordered by Publish-Order
       if: inputs.crates == ''
       run: |
-        echo "CRATES=\"$( \
+        echo "CRATES=\""${$( \
           cargo workspaces exec --no-bail \
             sh -c ' \
               name=$(basename $(pwd)); \
@@ -101,7 +101,7 @@ jobs:
                 | grep -w -q $name \
               && echo $name \
             ' \
-        )\"" >> $GITHUB_ENV
+        )//$'\n'/ }\"" >> $GITHUB_ENV
 
     # Package the crates that will be published. Verification is disabled
     # because we aren't ready to verify yet. Add each crate that was packaged to

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -95,7 +95,6 @@ jobs:
       id: crates
       with:
         script: |
-          const exec = require("@actions/exec");
           let crates = await exec.exec("cargo workspaces exec --no-bail sh -c 'basename $(pwd)'");
           return crates;
         result-encoding: string

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -112,7 +112,7 @@ jobs:
           let crates_need_publish = crates_need_publish_str.split("\n");
 
           // Filter the crates to those that publish.
-          let crates_to_publish = crates.filter((c) => crates_to_publish.includes(c));
+          let crates_to_publish = crates.filter((c) => crates_need_publish.includes(c));
 
           return crates_to_publish.join(" ");
         result-encoding: string

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -91,17 +91,7 @@ jobs:
     # the list of returned crates by crates that are marked for publishing.
     - name: Prepare List of Crates Ordered by Publish-Order
       if: inputs.crates == ''
-      run: >
-        echo "CRATES=\""${$(
-          cargo workspaces exec --no-bail
-            sh -c '
-              name=$(basename $(pwd));
-              cargo metadata --format-version 1 --no-deps
-                | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"'
-                | grep -w -q $name
-              && echo $name
-            '
-        )//$'\n'/ }\"" >> $GITHUB_ENV
+      run: echo "CRATES=\""${$(cargo workspaces exec --no-bail sh -c 'name=$(basename $(pwd)); cargo metadata --format-version 1 --no-deps | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' | grep -w -q $name && echo $name')//$'\n'/ }\"" >> $GITHUB_ENV
 
     # Package the crates that will be published. Verification is disabled
     # because we aren't ready to verify yet. Add each crate that was packaged to

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       crates:
         description: 'Space separated list of crate names in the order to be published.'
-        required: true
+        required: false
         type: string
       runs-on:
         required: false
@@ -65,6 +65,16 @@ jobs:
         name: cargo-hack
         version: 0.5.28
 
+    - uses: stellar/binaries@v25
+      with:
+        name: cargo-workspaces
+        version: 0.2.35
+
+    # Create the vendor directory because it'll only be created in the next step
+    # if the crate has dependencies, but it's needed for the latter steps in all
+    # cases.
+    - run: mkdir -p vendor
+
     # Vendor all the dependencies into the vendor/ folder. Temporarily remove
     # [patch.crates-io] entries in the workspace Cargo.toml that reference git
     # repos. These will be removed when published.
@@ -75,6 +85,23 @@ jobs:
         cargo vendor --versioned-dirs
         rm Cargo.toml
         mv Cargo.toml.bak Cargo.toml
+
+    # If a list of crates weren't provided, prepare a list by asking
+    # cargo-workspaces for the order it would publish the crates in, and filter
+    # the list of returned crates by crates that are marked for publishing.
+    - name: Prepare List of Crates Ordered by Publish-Order
+      if: inputs.crates == ''
+      run: |
+        echo "CRATES=\"$( \
+          cargo workspaces exec --no-bail \
+            sh -c ' \
+              name=$(basename $(pwd)); \
+              cargo metadata --format-version 1 --no-deps \
+                | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' \
+                | grep -w -q $name \
+              && echo $name \
+            ' \
+        )\"" >> $GITHUB_ENV
 
     # Package the crates that will be published. Verification is disabled
     # because we aren't ready to verify yet. Add each crate that was packaged to

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -95,7 +95,23 @@ jobs:
       id: crates
       with:
         script: |
-          let crates = await exec.exec("cargo", ["workspaces", "exec", "--no-bail", "sh", "-c", "basename $(pwd)"]);
+          let crates = "";
+          await exec.exec(
+            "cargo",
+            [
+              "workspaces",
+              "exec",
+              "--no-bail",
+              "sh",
+              "-c",
+              "basename $(pwd)",
+            ],
+            {
+              listeners: {
+                stdout: (data: Buffer) => { crates += data.toString(); },
+              },
+            },
+          );
           return crates;
         result-encoding: string
     - name: List of Crates

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -95,7 +95,7 @@ jobs:
       id: crates
       with:
         script: |
-          let crates = await exec.exec("cargo workspaces exec --no-bail sh -c 'basename $(pwd)'");
+          let crates = await exec.exec("cargo", ["workspaces", "exec", "--no-bail", "sh", "-c", "basename $(pwd)"]);
           return crates;
         result-encoding: string
     - name: List of Crates

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -95,24 +95,14 @@ jobs:
       id: crates
       with:
         script: |
-          let crates = "";
+          let crates_list = "";
           await exec.exec(
             "cargo",
-            [
-              "workspaces",
-              "exec",
-              "--no-bail",
-              "sh",
-              "-c",
-              "basename $(pwd)",
-            ],
-            {
-              listeners: {
-                stdout: (data) => { crates += data.toString(); },
-              },
-            },
+            [ "workspaces", "exec", "--no-bail", "sh", "-c", "basename $(pwd)" ],
+            { listeners: { stdout: (buf) => { crates_list += buf.toString(); } } },
           );
-          return crates;
+          let crates = crates_list.split("\n");
+          return crates.join(" ");
         result-encoding: string
     - name: List of Crates
       run: echo "${{steps.crates.outputs.result}}"

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -89,7 +89,6 @@ jobs:
     # If a list of crates weren't provided, prepare a list by asking
     # cargo-workspaces for the order it would publish the crates in, and filter
     # the list of returned crates by crates that are marked for publishing.
-    # '); cargo metadata --format-version 1 --no-deps | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' | grep -w -q $name && echo $name'');
     - name: Prepare List of Crates Ordered by Publish-Order
       uses: actions/github-script@v7
       id: crates

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -91,8 +91,7 @@ jobs:
     # the list of returned crates by crates that are marked for publishing.
     # '); cargo metadata --format-version 1 --no-deps | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' | grep -w -q $name && echo $name'');
     - name: Prepare List of Crates Ordered by Publish-Order
-      run: echo "CRATES=\""${$()//$'\n'/ }\"" >> $GITHUB_ENV
-    - uses: actions/github-script@v7
+      uses: actions/github-script@v7
       id: crates
       with:
         script: |

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -91,16 +91,16 @@ jobs:
     # the list of returned crates by crates that are marked for publishing.
     - name: Prepare List of Crates Ordered by Publish-Order
       if: inputs.crates == ''
-      run: |
-        echo "CRATES=\""${$( \
-          cargo workspaces exec --no-bail \
-            sh -c ' \
-              name=$(basename $(pwd)); \
-              cargo metadata --format-version 1 --no-deps \
-                | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"' \
-                | grep -w -q $name \
-              && echo $name \
-            ' \
+      run: >
+        echo "CRATES=\""${$(
+          cargo workspaces exec --no-bail
+            sh -c '
+              name=$(basename $(pwd));
+              cargo metadata --format-version 1 --no-deps
+                | jq -r '"'"'.packages[] | select(.publish != []) | .name'"'"'
+                | grep -w -q $name
+              && echo $name
+            '
         )//$'\n'/ }\"" >> $GITHUB_ENV
 
     # Package the crates that will be published. Verification is disabled

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -112,7 +112,7 @@ jobs:
           let metadata = JSON.parse(metadata_str);
 
           // Filter the crates to those that publish.
-          let crates_that_publish = crates.filter((c) => metadata.packages.find((p) => p.name == c).publish !== []);
+          let crates_that_publish = crates.filter((c) => metadata.packages.some((p) => p.name == c && p.publish !== []));
 
           return crates_that_publish.join(" ");
         result-encoding: string

--- a/.github/workflows/rust-publish-dry-run.yml
+++ b/.github/workflows/rust-publish-dry-run.yml
@@ -1,9 +1,6 @@
-# WARNING: This publish dry run process will not work on repositories that have
-# a crate containing bin targets that are dependent on other crates in the
-# repository. Please use `rust-publish-dry-run-v2` for any repository containing
-# binaries.
+# Deprecated. Use publish-dry-run-v2.yml.
 #
-# For more details, see https://github.com/rust-lang/cargo/issues/11181.
+# This workflow calls through to the v2 workflow.
 
 name: Publish Dry Run
 
@@ -26,67 +23,8 @@ on:
 jobs:
 
   publish-dry-run:
-    runs-on: ${{ inputs.runs-on }}
-    defaults:
-      run:
-        shell: bash
-    env:
-      CARGO_BUILD_TARGET: ${{ inputs.target }}
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: stellar/actions/rust-cache@main
-
-    - run: rustup update
-    - run: rustup target add ${{ inputs.target }}
-    - if: inputs.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-    - uses: stellar/binaries@v21
-      with:
-        name: cargo-hack
-        version: 0.5.28
-
-    # Create the vendor directory because it'll only be created in the next step
-    # if the crate has dependencies, but it's needed for the latter steps in all
-    # cases.
-    - run: mkdir -p vendor
-
-    # Vendor all the dependencies into the vendor/ folder. Temporarily remove
-    # [patch.crates-io] entries in the workspace Cargo.toml that reference git
-    # repos. These will be removed when published.
-    - run: |
-        cp Cargo.toml Cargo.toml.bak
-        sed -r '/(git|rev) ?=/d' Cargo.toml.bak > Cargo.toml
-        cargo vendor --versioned-dirs
-        rm Cargo.toml
-        mv Cargo.toml.bak Cargo.toml
-
-    # Package the crates that will be published. Verification is disabled because
-    # we aren't ready to verify yet.
-    - run: cargo-hack hack --ignore-private package --no-verify ${{ inputs.cargo-package-options }}
-
-    # Add each crate that was packaged to the vendor/ directory.
-    - run: |
-        for crate in target/package/*.crate
-        do
-          name=$(basename "$crate" .crate)
-          tar xvfz "$crate" -C vendor/
-          # Crates in the vendor directory require a checksum file, but it doesn't
-          # matter if it is empty.
-          echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
-        done
-
-    # Rerun the package command but with verification enabled this time. Tell
-    # cargo to use the local vendor/ directory as the source for all packages. Run
-    # the package command on the full feature powerset so that all features of
-    # each crate are verified to compile.
-    - run: >
-        cargo-hack hack
-        ${{ inputs.cargo-hack-feature-options }}
-        --ignore-private
-        --config "source.crates-io.replace-with = 'vendored-sources'"
-        --config "source.vendored-sources.directory = 'vendor'"
-        package
-        --target ${{ inputs.target }}
+    uses: ./.github/workflows/rust-publish-dry-run-v2.yml
+    with:
+      runs-on: ${{ inputs.runs-on }}
+      target: ${{ inputs.target }}
+      cargo-hack-feature-options: ${{ inputs.cargo-hack-feature-options }}


### PR DESCRIPTION
### What
Make publish-dry-run-v2 work without a list of crates and deprecate v1.

### Why
v1 was able to work out what crates to publish, but it had an issue that showed up only on some repos where it would trigger cargo looking up crates on crates.io before they had been published which would fail because the process of packaging the crates for a dry run wasn't preserving the order or using the local registry.

v2 was written to replace v1 but v2 was written requiring an explicit list of crates in the order to publish to avoid the lookups on crates.io.

This change makes v2 no longer require the explicit list by using cargo-workspaces (the tool we use to do actual publishes) to produce a list of crates that need publishing in the order they need publishing.

With this change v2 now works with the same inputs as v1 and so v1 can be completely deprecated and can call through to v2.

Even though the crates list input is no longer needed it remains for backwards compatibility.