### PR TITLE
Set the userid on the GH bot for pushes in bump-version

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -30,8 +30,8 @@ jobs:
         cargo set-version ${{ inputs.version }}
     - name: Create Commit
       run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
         git checkout -b 'release/v${{ inputs.version }}'
         git add .
         git commit -m 'Bump version to ${{ inputs.version }}'


### PR DESCRIPTION
### What
Set the userid on the GH bot for pushes in the bump-version action and remove modifications to global git config.

### Why
The userid is the recommended way to reference the GH bot now:
- https://github.com/actions/checkout/pull/1707

The accompanying changes to remove the `--global` makes our use consistent with the PR above's recommendations.

We started to see failing builds that do a git push as the GH bot, e.g.:
- https://github.com/stellar/rs-soroban-env/actions/runs/10446231617/job/28923346397

Nothing changes on our side that I'm aware of, although I have an ask out to ops at the thread below to confirm:
- https://stellarfoundation.slack.com/archives/C02U19A2A/p1723857725537729

Folks in this community forum got it working again by removing modifications to the global git config:
- https://github.com/orgs/community/discussions/35410

These changes might not fix the problem, but they're updating our existing use to match recommendations so are good to make regardless.