### PR TITLE
Update rust-bump-version.yml to use actions/checkout@v4

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -17,7 +17,7 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - uses: stellar/binaries@v21


### PR DESCRIPTION
### What
Update rust-bump-version.yml to use actions/checkout@v4.

### Why
GitHub Support suggested it could fix the permissions issues we started encountering a few days ago.