### PR TITLE
Fix use of base when bumping version off a base

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.base }}
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - uses: stellar/binaries@v21


### PR DESCRIPTION
### What
Change what ref is checked out and changes are applied to be the `base` that is specified in the inputs.

### Why
When bumping off a base the changes aren't being made off the base, but should be because that's the point it should fork off.