### PR TITLE
Update apt-get before installing additional deb packages

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install additional dependencies (Linux)
       if: (inputs.target == 'aarch64-unknown-linux-gnu' || inputs.target == 'x86_64-unknown-linux-gnu') && inputs.additional-deb-packages != ''
-      run: sudo apt-get -y install ${{ inputs.additional-deb-packages }}
+      run: sudo apt-get update && sudo apt-get -y install ${{ inputs.additional-deb-packages }}
 
     # macOS comes with an old version of `make` that causes issues when building
     # some projects


### PR DESCRIPTION
I was seeing the following failure in the stellar-cli CI. Other occurances of this seemed to be fix by first updating apt-get before installing the packages.

```
Run sudo apt-get -y install libudev-dev libdbus-1-dev
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  libdbus-1-dev libudev-dev
0 upgraded, 2 newly installed, 0 to remove and 29 not upgraded.
Need to get 212 kB of archives.
After this operation, 1203 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libdbus-1-dev amd64 1.14.[10](https://github.com/stellar/stellar-cli/actions/runs/13182781772/job/36800135945#step:8:11)-4ubuntu4.1 [190 kB]
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.4
Ign:3 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.4
Err:3 http://security.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.4
  404  Not Found [IP: 52.[14](https://github.com/stellar/stellar-cli/actions/runs/13182781772/job/36800135945#step:8:15)7.219.192 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_255.4-1ubuntu8.4_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched [19](https://github.com/stellar/stellar-cli/actions/runs/13182781772/job/36800135945#step:8:20)0 kB in 0s (478 kB/s)
```

