### PR TITLE
Use github actions/cache@v4 as required by github deprecation

### DIFF
--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -3,7 +3,7 @@ description: 'Cache rust dep and build artifacts'
 runs:
   using: "composite"
   steps:
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     with:
       path: |
         ~/.cargo/registry/index/
@@ -13,7 +13,7 @@ runs:
         cargo-deps-${{ hashFiles('**/Cargo.lock') }}
       restore-keys: |
         cargo-deps-
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     with:
       path: ~/.cargo/target/
       key: |
@@ -54,7 +54,7 @@ runs:
     run: |
       echo "RUSTC_WRAPPER=$HOME/.local/bin/sccache${{ runner.os == 'Windows' && '.exe' || '' }}" >> $GITHUB_ENV
       echo 'SCCACHE_CACHE_SIZE=9G' >> $GITHUB_ENV
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     with:
       path: ~/.cache/sccache
       key: |


### PR DESCRIPTION
Github deprecated actions/cache@v3, so this bumps us to v4.