### PR TITLE
Add permissions to rust-bump-version workflow

### DIFF
--- a/.github/workflows/rust-bump-version.yml
+++ b/.github/workflows/rust-bump-version.yml
@@ -12,6 +12,11 @@ on:
         type: 'string'
         required: true
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
 jobs:
 
   bump-version:


### PR DESCRIPTION
### What
Add permissions for actions, contents, and pull-requests to the rust-bump-version workflow.

### Why
Something has changed with GitHub, and explicit permissions are required for the workflow to create commits and pull requests when bumping versions when being created from previous tags.