### PR TITLE
Add rust-publish-v2 workflow

### DIFF
--- a/.github/workflows/rust-publish-v2.yml
+++ b/.github/workflows/rust-publish-v2.yml
@@ -1,0 +1,28 @@
+name: Publish v2
+
+on:
+  workflow_call:
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: true
+    inputs:
+      additional-deb-packages:
+        description: 'Space separated list of .deb packages that will be installed on ubuntu.'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install additional dependencies (Linux)
+      if: inputs.additional-deb-packages != ''
+      run: sudo apt-get update && sudo apt-get -y install ${{ inputs.additional-deb-packages }}
+    - uses: actions/checkout@v4
+    - uses: stellar/actions/rust-cache@main
+    - run: rustup update
+    - run: cargo publish --workspace
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ workflows.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | [rust-bump-version] | Workflow | Updates the version in Rust crates to a input version. |
-| [rust-publish-dry-run] | Run a package verification on all crates in a workspace in their published form that automatically figures out the crate dependencies and order to publish (works only for repos without a binary). |
-| [rust-publish-dry-run-v2] | Run a package verification on all crates in a workspace in their published form that requires an explicit list of crates to publish (works with all repos). |
+| [rust-publish-dry-run] | Workflow | Run a package verification on all crates in a workspace in their published form that automatically figures out the crate dependencies and order to publish (works only for repos without a binary). |
+| [rust-publish-dry-run-v2] | Workflow | Run a package verification on all crates in a workspace in their published form that requires an explicit list of crates to publish (works with all repos). |
 | [rust-publish] | Workflow | Publish all crates in a workspace using `cargo-workspaces`. |
 | [rust-publish-v2] | Workflow | Publish all crates in a workspace using the built-in `cargo publish --workspace` command. |
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ workflows.
 | [rust-bump-version] | Workflow | Updates the version in Rust crates to a input version. |
 | [rust-publish-dry-run] | Run a package verification on all crates in a workspace in their published form that automatically figures out the crate dependencies and order to publish (works only for repos without a binary). |
 | [rust-publish-dry-run-v2] | Run a package verification on all crates in a workspace in their published form that requires an explicit list of crates to publish (works with all repos). |
-| [rust-publish] | Workflow | Publish all crates in a workspace. |
+| [rust-publish] | Workflow | Publish all crates in a workspace using `cargo-workspaces`. |
+| [rust-publish-v2] | Workflow | Publish all crates in a workspace using the built-in `cargo publish --workspace` command. |
 
 ### Project Management
 
@@ -70,6 +71,7 @@ workflows.
 [rust-publish-dry-run]: ./.github/workflows/rust-publish-dry-run.yml
 [rust-publish-dry-run-v2]: ./.github/workflows/rust-publish-dry-run-v2.yml
 [rust-publish]: ./.github/workflows/rust-publish.yml
+[rust-publish-v2]: ./.github/workflows/rust-publish-v2.yml
 [update-completed-sprint-on-issue-closed]: ./.github/workflows/update-completed-sprint-on-issue-closed.yml
 [disk-cleanup]: ./disk-cleanup
 [sdf-ecr-login]: ./sdf-ecr-login/action.yml

--- a/rust-publish-v2/workflow.yml
+++ b/rust-publish-v2/workflow.yml
@@ -1,0 +1,1 @@
+../.github/workflows/rust-publish-v2.yml


### PR DESCRIPTION
### What
Add a `rust-publish-v2` reusable workflow that publishes all crates in a workspace using the built-in `cargo publish --workspace` command.

### Why
The existing `rust-publish` workflow relies on `cargo-workspaces` to manage publish order. Since the rust-publish workflow was created the official cargo publish command has gained support for publishing workspaces correctly by ordering the publishes so they will succeed. Now that cargo publish is more complete there is little need for us to use cargo-workspace in this workflow any longer, and it removes one additional supply chain risk and moving part in workflows that have access to secret tokens.

### Rollout
I'm adding this as a separate workflow because that's the pattern we've used in the past and it worked well and minimised interruption while still confirming if it worked. But if the workflow proves to work well, we can just update the `rust-publish` workflow with the change too.