### PR TITLE
Make rust-cache sccache download network-resilient

### DIFF
--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -47,7 +47,7 @@ runs:
     run: |
       curl --fail --location \
         --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors \
-        --connect-timeout 30 \
+        --connect-timeout 30 --max-time 300 \
         --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       $SHASUM -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
       mkdir -p "$HOME/.local/bin"

--- a/rust-cache/action.yml
+++ b/rust-cache/action.yml
@@ -45,7 +45,10 @@ runs:
       SCCACHE_BIN_FILE: sccache${{ runner.os == 'Windows' && '.exe' || '' }}
       SHASUM: ${{ runner.os == 'macOS' && 'shasum' || 'sha256sum' }}
     run: |
-      curl --fail --location --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
+      curl --fail --location \
+        --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors \
+        --connect-timeout 30 \
+        --output /tmp/$SCCACHE_FILE https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_FILE
       $SHASUM -c <(echo "$SCCACHE_FILE_SHA256  /tmp/$SCCACHE_FILE")
       mkdir -p "$HOME/.local/bin"
       tar xz -f /tmp/$SCCACHE_FILE -C "$HOME/.local/bin" --strip-components=1 $SCCACHE_DIR/$SCCACHE_BIN_FILE


### PR DESCRIPTION
### What

Add retry and connection-timeout options to the curl invocation that downloads the sccache release tarball in the rust-cache action, so a single unsuccessful response no longer fails the job outright.

### Why

A job using rust-cache@main failed with curl exit code 22, which curl returns under `--fail` when the server responds with an HTTP status of 400 or above while fetching the sccache binary from GitHub releases. The failing job: https://github.com/stellar/binaries/actions/runs/27119374274/job/80033796245?pr=82. The download was the only network call in the action without any retry handling, so a transient server-side error (rate limiting, 5xx, a momentary CDN hiccup) aborted the whole build. Retrying up to five times with a delay — including on connection-refused and other transient errors — lets these recover automatically, while the existing sha256 checksum verification still guards against accepting a corrupt or partial download.