### PR TITLE
Extend Publish Dry Run v2 with optional env vars

### DIFF
--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -28,7 +28,7 @@ on:
         required: false
         default: ''
         type: string
-      additional-env:
+      env:
         description: 'Newline separated KEY=VALUE pairs set as environment variables for the build.'
         required: false
         default: ''
@@ -50,11 +50,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Set additional environment variables
-      if: inputs.additional-env != ''
+    - name: Set environment variables
+      if: inputs.env != ''
       run: printf '%s\n' "$ADDITIONAL_ENV" >> "$GITHUB_ENV"
       env:
-        ADDITIONAL_ENV: ${{ inputs.additional-env }}
+        ADDITIONAL_ENV: ${{ inputs.env }}
 
     - uses: stellar/actions/rust-cache@main
 

--- a/.github/workflows/rust-publish-dry-run-v2.yml
+++ b/.github/workflows/rust-publish-dry-run-v2.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ''
         type: string
+      additional-env:
+        description: 'Newline separated KEY=VALUE pairs set as environment variables for the build.'
+        required: false
+        default: ''
+        type: string
 
 jobs:
 
@@ -44,6 +49,12 @@ jobs:
     - uses: stellar/actions/disk-cleanup@main
 
     - uses: actions/checkout@v4
+
+    - name: Set additional environment variables
+      if: inputs.additional-env != ''
+      run: printf '%s\n' "$ADDITIONAL_ENV" >> "$GITHUB_ENV"
+      env:
+        ADDITIONAL_ENV: ${{ inputs.additional-env }}
 
     - uses: stellar/actions/rust-cache@main
 


### PR DESCRIPTION
### What

Add an optional input `additional_env` to `publish-dry-run-v2`

### Why

The `rs-soroban-sdk` requires a specific env flag to be present when built for `wasm32v1-none`. This allows the SDK to dry run against the Wasm target.

### Known Limitations

The `additional_env` is written to `GITHUB_ENV`. This is unsafe for untrusted input. This job should not be run where user provided input can set `additional_env`.