### PR TITLE
Add composite Github action for PR Previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
 | [rust-set-rust-version] | Workflow | Updates the rust-version in Rust crates to the latest stable version. |
 | [rust-check-git-rev-deps] | Workflow | Check that git rev dependencies do not reference revisions likely to be orphaned. |
 | [sdf-ecr-login] | Action | Abstraction for SDF's AWS ECR login steps. |
+| [sdf-pr-preview] | Action | Builds and publishes an ArgoCD-deployed preview environment for org-member PRs. |
 
 #### Releasing / Publishing
 
@@ -81,4 +82,5 @@ workflows.
 [update-completed-sprint-on-issue-closed]: ./.github/workflows/update-completed-sprint-on-issue-closed.yml
 [disk-cleanup]: ./disk-cleanup
 [sdf-ecr-login]: ./sdf-ecr-login/action.yml
+[sdf-pr-preview]: ./sdf-pr-preview
 [README-rust-release.md]: README-rust-release.md

--- a/sdf-pr-preview/README.md
+++ b/sdf-pr-preview/README.md
@@ -1,0 +1,82 @@
+# PR Preview — Composite Action
+
+Builds and publishes a per-PR preview environment for org-member PRs. On every push to an open PR it builds the Docker image, pushes it to ECR, labels the PR with `preview` so ArgoCD's ApplicationSet picks it up, and comments the preview URL. When the PR closes (merged or not), it removes the label and comments that the preview was torn down. ArgoCD does the actual deploying — this action only produces the image and the signal.
+
+## How it works
+
+1. **PR closed?** Remove the `preview` label and comment "torn down". Nothing else runs.
+2. **Org-membership gate.** A GitHub App token checks whether the PR author is a member of the org (`GITHUB_TOKEN` cannot read org membership). The gate applies to every PR — branch or fork — so an org member's fork PR gets a preview while an outside contributor's does not.
+3. **Non-member PR:** any stale `preview` label is removed. This keeps CI authoritative — a hand-applied label cannot create a preview for an image that was never built.
+4. **Member PR:** check out the PR head SHA (not the synthetic merge commit), build the image, push it to ECR as `<registry>/<ecr-repository>:pr-<number>-<head-sha>`, then — only after the push succeeds — add the `preview` label and comment `https://<preview-host>` on the PR.
+
+ECR authentication (OIDC, role assumption, registry login) is handled internally via [`stellar/actions/sdf-ecr-login`](../sdf-ecr-login).
+
+## Usage
+
+Composite actions cannot declare triggers, permissions, or concurrency — the caller workflow must provide them exactly as below.
+
+```yaml
+# .github/workflows/pr-preview.yml
+
+name: pr-preview
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+# pull_request_target runs in base-repo context, so these are real write
+# permissions even for fork PRs. That is the entire reason this event is used:
+# on `pull_request`, fork runs get no OIDC token and a read-only token.
+permissions:
+  contents: read
+  id-token: write        # OIDC -> AWS. Silently ignored on `pull_request` forks.
+  pull-requests: write   # labels + comments
+
+# A rapid second push cancels the in-flight build rather than racing it.
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: stellar/actions/sdf-pr-preview@main
+        with:
+          app-id: ${{ vars.PREVIEW_BOT_APP_ID }}
+          private-key: ${{ secrets.PREVIEW_BOT_PRIVATE_KEY }}
+          ecr-repository: dev/stellar-design-system
+          preview-host: design-system-pr-${{ github.event.pull_request.number }}.preview.stellar.org
+```
+
+
+Either way, the action itself checks out the PR **head** SHA before building, replacing the workspace. The build always runs against the contributor's actual commit, and that SHA is what the ApplicationSet must inject as `{{ .head_sha }}`.
+
+## Inputs
+
+| Input | Required | Description |
+|---|---|---|
+| `app-id` | yes | GitHub App ID used to check org membership |
+| `private-key` | yes | Private key of that GitHub App |
+| `ecr-repository` | yes | ECR repository to push the preview image to (e.g. `dev/stellar-design-system`) |
+| `preview-host` | yes | Hostname the preview will be served on; commented on the PR as `https://<preview-host>` |
+
+## Prerequisites
+
+- **`preview` label** — must already exist in the repo; the action adds/removes it but does not create it.
+- **GitHub App** — installed on the org, with permission to read organization members. Its ID and private key are passed as `app-id` / `private-key`.
+- **ArgoCD ApplicationSet** — a PR generator watching the repo for the `preview` label, deploying `<registry>/<ecr-repository>:pr-{{ .number }}-{{ .head_sha }}` and routing `preview-host` to it. The label is applied only after the image push succeeds, so the ApplicationSet never renders an Application whose image does not exist yet.
+- **AWS OIDC** — the repo must be able to assume the ECR push role used by [`sdf-ecr-login`](../sdf-ecr-login) (hence `id-token: write`).
+- **Dockerfile** — at the repo root; the image is built with `context: .` using Buildx with GitHub Actions cache (`type=gha`).
+
+## Security notes
+
+The workflow runs on `pull_request_target`, which executes in the base repo's context with real secrets and write permissions — including for fork PRs. This is safe here because:
+
+- No fork code is checked out or executed before the org-membership gate; the App token is only ever handled by trusted steps.
+- The PR head is checked out only for PRs authored by org members, and only to `docker build` it — no repo scripts are run directly on the runner.
+- Do not add steps to the caller workflow that run PR-controlled code before the action.
+
+## Teardown
+
+Teardown on close is technically redundant with the ApplicationSet generator (a closed PR leaves its result set anyway), but removing the label explicitly makes it immediate and leaves a trace in the PR timeline.

--- a/sdf-pr-preview/action.yml
+++ b/sdf-pr-preview/action.yml
@@ -1,0 +1,148 @@
+# Builds a preview image for org-member PRs, marks the PR so ArgoCD's
+# ApplicationSet picks it up, and comments the URL. Handles teardown when the
+# PR closes. ArgoCD does the actual deploying.
+#
+# Composite actions cannot declare triggers, permissions, or concurrency.
+# The caller workflow must run this on `pull_request_target` (types: opened,
+# synchronize, reopened, closed) with `contents: read`, `id-token: write`,
+# `pull-requests: write`, and a per-PR concurrency group.
+# See .github/workflows/pr-preview.yml.
+
+name: 'PR Preview'
+description: 'Build and publish an ArgoCD-deployed preview image for org-member PRs'
+
+inputs:
+  app-id:
+    description: 'GitHub App ID used to check org membership'
+    required: true
+  private-key:
+    description: 'Private key of that GitHub App'
+    required: true
+  ecr-repository:
+    description: 'ECR repository to push the preview image to (e.g. dev/stellar-design-system)'
+    required: true
+  preview-host:
+    description: 'Hostname the preview will be served on'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # -------------------------------------------------------------------------
+    # PR closed or merged: immediate teardown, then nothing else runs.
+    # Redundant with the generator (a closed PR leaves its result set anyway),
+    # but it makes teardown immediate and leaves a trace in the PR timeline.
+    # -------------------------------------------------------------------------
+    - name: Remove preview label
+      if: github.event.action == 'closed'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label preview || true
+
+    - name: Comment teardown
+      if: github.event.action == 'closed'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: >-
+        gh pr comment "${{ github.event.pull_request.number }}"
+        --body 'PR Preview: torn down'
+
+    # -------------------------------------------------------------------------
+    # Gate: is the PR author a member of the org?
+    # GITHUB_TOKEN cannot read org membership, so this needs an App token.
+    # The gate applies to every PR - branch or fork - so an org member's fork
+    # PR gets a preview while an outside collaborator's does not.
+    # Safe on fork PRs: no fork code has been checked out or run at this
+    # point, so the App token is only ever handled by trusted steps.
+    # -------------------------------------------------------------------------
+    - id: app-token
+      if: github.event.action != 'closed'
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ github.repository_owner }}
+
+    - id: check
+      if: github.event.action != 'closed'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        AUTHOR: ${{ github.event.pull_request.user.login }}
+        ORG: ${{ github.repository_owner }}
+      run: |
+        # 204 = member (including private membership), 404 = not a member.
+        if gh api "/orgs/${ORG}/members/${AUTHOR}" --silent 2>/dev/null; then
+          echo "member=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::${AUTHOR} is a member of ${ORG} - preview enabled"
+        else
+          echo "member=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::${AUTHOR} is not a member of ${ORG} - preview skipped"
+        fi
+
+    # -------------------------------------------------------------------------
+    # Non-member PR: make sure no stale label survives.
+    # Keeps CI authoritative - a hand-applied label cannot create a preview
+    # for an image that was never built.
+    # -------------------------------------------------------------------------
+    - name: Revoke preview label
+      if: github.event.action != 'closed' && steps.check.outputs.member != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label preview || true
+
+    # -------------------------------------------------------------------------
+    # Member PR: build, push, then mark the PR.
+    # This checkout replaces the caller's base-ref workspace with the PR head,
+    # not the synthetic merge commit. This SHA must match what the
+    # ApplicationSet injects as {{ .head_sha }}.
+    # -------------------------------------------------------------------------
+    - uses: actions/checkout@v4
+      if: steps.check.outputs.member == 'true'
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
+
+    - uses: docker/setup-buildx-action@v3
+      if: steps.check.outputs.member == 'true'
+
+    # Handles OIDC auth, role assumption, and ECR login internally.
+    - id: ecr
+      if: steps.check.outputs.member == 'true'
+      uses: stellar/actions/sdf-ecr-login@main
+
+    - uses: docker/build-push-action@v6
+      if: steps.check.outputs.member == 'true'
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.ecr.outputs.ecr-registry }}/${{ inputs.ecr-repository }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    # Applied only after the push succeeds, so the ApplicationSet never
+    # renders an Application whose image does not exist yet.
+    # The `preview` label must already exist in the repo.
+    - name: Enable preview
+      if: steps.check.outputs.member == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: gh pr edit "${{ github.event.pull_request.number }}" --add-label preview
+
+    - name: Comment preview URL
+      if: steps.check.outputs.member == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: >-
+        gh pr comment "${{ github.event.pull_request.number }}"
+        --body "PR Preview: https://${{ inputs.preview-host }}"

--- a/sdf-pr-preview/action.yml
+++ b/sdf-pr-preview/action.yml
@@ -52,10 +52,17 @@ runs:
         --body 'PR Preview: torn down'
 
     # -------------------------------------------------------------------------
-    # Gate: is the PR author a member of the org?
+    # Gate: every identity that could have supplied the head commit must be an
+    # org member, not just the PR opener:
+    #   - AUTHOR: who opened the PR. Not enough on its own - a member can open
+    #     a PR from a fork someone else controls.
+    #   - ACTOR: who triggered THIS run. On `synchronize` that is whoever
+    #     pushed the new head, so an outsider pushing to a member's fork
+    #     fails the gate even though the member opened the PR.
+    #   - HEAD_OWNER: who owns the head repository. For same-repo PRs this is
+    #     the org itself; for forks the fork owner must be a member, so an
+    #     outsider-controlled fork is never built regardless of who opened it.
     # GITHUB_TOKEN cannot read org membership, so this needs an App token.
-    # The gate applies to every PR - branch or fork - so an org member's fork
-    # PR gets a preview while an outside collaborator's does not.
     # Safe on fork PRs: no fork code has been checked out or run at this
     # point, so the App token is only ever handled by trusted steps.
     # -------------------------------------------------------------------------
@@ -73,15 +80,33 @@ runs:
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
         AUTHOR: ${{ github.event.pull_request.user.login }}
+        ACTOR: ${{ github.actor }}
+        HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         ORG: ${{ github.repository_owner }}
       run: |
         # 204 = member (including private membership), 404 = not a member.
-        if gh api "/orgs/${ORG}/members/${AUTHOR}" --silent 2>/dev/null; then
-          echo "member=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::${AUTHOR} is a member of ${ORG} - preview enabled"
-        else
-          echo "member=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::${AUTHOR} is not a member of ${ORG} - preview skipped"
+        is_member() {
+          gh api "/orgs/${ORG}/members/$1" --silent 2>/dev/null
+        }
+
+        trusted=true
+        for login in "$AUTHOR" "$ACTOR"; do
+          if ! is_member "$login"; then
+            echo "::notice::${login} is not a member of ${ORG} - preview skipped"
+            trusted=false
+          fi
+        done
+
+        # Same-repo PRs: head owner IS the org. Anything else must be a
+        # member's personal fork.
+        if [ "$HEAD_OWNER" != "$ORG" ] && ! is_member "$HEAD_OWNER"; then
+          echo "::notice::head repo owner ${HEAD_OWNER} is not a member of ${ORG} - preview skipped"
+          trusted=false
+        fi
+
+        echo "member=${trusted}" >> "$GITHUB_OUTPUT"
+        if [ "$trusted" = "true" ]; then
+          echo "::notice::author, actor, and head repo owner are all members of ${ORG} - preview enabled"
         fi
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
### What:

- Add composite PR Previews action.
- This action checks if PR author belongs to SDF org.
- It builds the image and pushes to the registry.
- Adds preview label to PR to trigger ApplicationSet on ArgoCD.

### Why:

We need a generic action to handle PR previews.


### Issue:

https://github.com/stellar/ops/issues/4824