### PR TITLE
Split sdf-pr-preview into gate + publish around the caller's build

### DIFF
--- a/sdf-pr-preview/README.md
+++ b/sdf-pr-preview/README.md
@@ -1,15 +1,24 @@
-# PR Preview — Composite Action
+# PR Preview — Composite Actions
 
-Builds and publishes a per-PR preview environment for org-member PRs. On every push to an open PR it builds the Docker image, pushes it to ECR, labels the PR with `preview` so ArgoCD's ApplicationSet picks it up, and comments the preview URL. When the PR closes (merged or not), it removes the label and comments that the preview was torn down. ArgoCD does the actual deploying — this action only produces the image and the signal.
+Per-PR preview environments for org-member PRs, deployed by ArgoCD. On every push to an open PR the flow builds the preview image(s), pushes them to ECR, labels the PR with `preview` so ArgoCD's ApplicationSet picks it up, and comments the preview URL. When the PR closes (merged or not), it removes the label and comments that the preview was torn down. ArgoCD does the actual deploying — these actions only produce the images and the signal.
+
+The flow is two actions that bracket your build, so your repo owns how its images are built (Makefiles, multiple images, non-root Dockerfiles) without weakening the security model:
+
+| Step | Who | Role |
+|---|---|---|
+| [`sdf-pr-preview/gate`](./gate) | this repo | **Policy.** Withdraws the `preview` label, handles teardown on close, checks org membership. Outputs `member` and `image-tag`. Must run before any PR code is touched. |
+| build & push | your workflow | Checkout PR head, build, push — every step guarded by `member == 'true'`, every image tagged with `image-tag`. |
+| [`sdf-pr-preview/publish`](./publish) | this repo | **Signal.** Verifies every image exists in the registry, then adds the label and comments the URL. |
 
 ## How it works
 
-1. **PR closed?** Remove the `preview` label and comment "torn down". Nothing else runs.
-2. **Org-membership gate.** A GitHub App token checks whether the PR author is a member of the org (`GITHUB_TOKEN` cannot read org membership). The gate applies to every PR — branch or fork — so an org member's fork PR gets a preview while an outside contributor's does not.
-3. **Non-member PR:** any stale `preview` label is removed. This keeps CI authoritative — a hand-applied label cannot create a preview for an image that was never built.
-4. **Member PR:** check out the PR head SHA (not the synthetic merge commit), build the image, push it to ECR as `<registry>/<ecr-repository>:pr-<number>-<head-sha>`, then — only after the push succeeds — add the `preview` label and comment `https://<preview-host>` on the PR.
+1. **Withdraw the signal** (`gate`). On every event, the `preview` label is removed first. The ApplicationSet derives `head_sha` from the live PR, so a label left over from a previous build would otherwise let it deploy `pr-<number>-<new-sha>` before that image is pushed — and point at a nonexistent tag for as long as that commit stays the head if the build fails. Removing it up front makes the signal fail closed: the label is present only while the images it implies exist. The tradeoff is that the preview goes dark while a rebuild is in flight.
+2. **PR closed?** (`gate`) The removal above is the teardown; a "torn down" comment is added and `member` is `false`, so nothing else runs.
+3. **Org-membership gate** (`gate`). A GitHub App token checks that the PR author, the actor who triggered the run, and the head-repo owner are all members of the org (`GITHUB_TOKEN` cannot read org membership). The gate applies to every PR — branch or fork — so an org member's fork PR gets a preview while an outside contributor's does not. Non-member PRs stop here: the up-front removal already revoked any stale or hand-applied label, so CI stays authoritative.
+4. **Build and push** (your workflow). Check out the PR head SHA — not the synthetic merge commit — build, and push each image as `<registry>/<repository>:<image-tag>`, where `image-tag` is `pr-<number>-<head-sha>`.
+5. **Publish** (`publish`). Confirm every listed image exists in the registry (`docker manifest inspect`), then — and only then — restore the `preview` label and comment `https://<preview-host>` on the PR. A failed or cancelled build, a miswired build step, or a mismatched tag all leave the label off, never a broken preview.
 
-ECR authentication (OIDC, role assumption, registry login) is handled internally via [`stellar/actions/sdf-ecr-login`](../sdf-ecr-login).
+There is one residual window: between a push landing and the workflow's first step running (typically seconds), the generator can observe the new `head_sha` with the previous run's label still attached and briefly render an Application for a not-yet-pushed tag. This self-heals as soon as the label removal runs; the ApplicationSet should tolerate a transiently missing image rather than treat it as fatal.
 
 ## Usage
 
@@ -41,42 +50,98 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: stellar/actions/sdf-pr-preview@main
+      # 1. Policy. Nothing that touches PR code may run before this.
+      - id: gate
+        uses: stellar/actions/sdf-pr-preview/gate@main
         with:
           app-id: ${{ vars.PREVIEW_BOT_APP_ID }}
           private-key: ${{ secrets.PREVIEW_BOT_PRIVATE_KEY }}
-          ecr-repository: dev/stellar-design-system
-          preview-host: design-system-pr-${{ github.event.pull_request.number }}.preview.stellar.org
+
+      # 2. Your build. EVERY step from here on is guarded by the gate.
+      #    Check out the PR head SHA, never the default base ref.
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.member == 'true'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - id: ecr
+        if: steps.gate.outputs.member == 'true'
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Build and push preview images
+        if: steps.gate.outputs.member == 'true'
+        env:
+          ECR_SERVER_TAG: ${{ steps.ecr.outputs.ecr-registry }}/dev/myapp-server:${{ steps.gate.outputs.image-tag }}
+          ECR_CLIENT_TAG: ${{ steps.ecr.outputs.ecr-registry }}/dev/myapp-client:${{ steps.gate.outputs.image-tag }}
+        run: |
+          export SERVER_TAG=${ECR_SERVER_TAG}
+          make docker-build-server
+          docker push ${SERVER_TAG}
+
+          export CLIENT_TAG=${ECR_CLIENT_TAG}
+          make docker-build-client
+          docker push ${CLIENT_TAG}
+
+      # 3. Signal. Verifies both images exist, then labels + comments.
+      - uses: stellar/actions/sdf-pr-preview/publish@main
+        if: steps.gate.outputs.member == 'true'
+        with:
+          images: |
+            ${{ steps.ecr.outputs.ecr-registry }}/dev/myapp-server:${{ steps.gate.outputs.image-tag }}
+            ${{ steps.ecr.outputs.ecr-registry }}/dev/myapp-client:${{ steps.gate.outputs.image-tag }}
+          preview-host: myapp-pr-${{ github.event.pull_request.number }}.preview.stellar.org
 ```
 
+A single-image repo is the same shape with one image: build it however you like (`docker build`, `docker/build-push-action`, `make`), tag it with `steps.gate.outputs.image-tag`, push it, and list it in `publish`'s `images`.
 
-Either way, the action itself checks out the PR **head** SHA before building, replacing the workspace. The build always runs against the contributor's actual commit, and that SHA is what the ApplicationSet must inject as `{{ .head_sha }}`.
+### Caller contract
 
-## Inputs
+The trust boundary lives in your workflow, so these are not optional:
+
+- `gate` runs **first**. No step before it may check out or execute PR code.
+- **Every** step after `gate` — checkout, registry login, build, push, `publish` — carries `if: steps.gate.outputs.member == 'true'`. A missing guard on the checkout means an outsider's fork is built under `pull_request_target` with a live OIDC token in the job.
+- Checkout uses `ref: ${{ github.event.pull_request.head.sha }}` and `persist-credentials: false`. The default checkout on `pull_request_target` is the base ref, which would build the wrong code.
+- Every preview image is tagged with `steps.gate.outputs.image-tag`, verbatim, and listed in `publish`'s `images`. That tag is what the ApplicationSet renders; a hand-rolled tag that drifts from it fails the existence check rather than deploying nothing.
+- Log in to the registry before `publish` runs. The existence check reuses the docker credentials your push already needed.
+
+## Inputs and outputs
+
+### `sdf-pr-preview/gate`
 
 | Input | Required | Description |
 |---|---|---|
 | `app-id` | yes | GitHub App ID used to check org membership |
 | `private-key` | yes | Private key of that GitHub App |
-| `ecr-repository` | yes | ECR repository to push the preview image to (e.g. `dev/stellar-design-system`) |
+
+| Output | Description |
+|---|---|
+| `member` | `'true'` when the event is not `closed` and the PR author, triggering actor, and head-repo owner are all org members; otherwise `'false'` |
+| `image-tag` | `pr-<number>-<head-sha>` — the tag every preview image must carry |
+
+### `sdf-pr-preview/publish`
+
+| Input | Required | Description |
+|---|---|---|
+| `images` | yes | Fully qualified image references (`registry/repository:tag`), one per line; every one must exist before the label is applied |
 | `preview-host` | yes | Hostname the preview will be served on; commented on the PR as `https://<preview-host>` |
 
 ## Prerequisites
 
-- **`preview` label** — must already exist in the repo; the action adds/removes it but does not create it.
+- **`preview` label** — must already exist in the repo; the actions add/remove it but do not create it.
 - **GitHub App** — installed on the org, with permission to read organization members. Its ID and private key are passed as `app-id` / `private-key`.
-- **ArgoCD ApplicationSet** — a PR generator watching the repo for the `preview` label, deploying `<registry>/<ecr-repository>:pr-{{ .number }}-{{ .head_sha }}` and routing `preview-host` to it. The label is applied only after the image push succeeds, so the ApplicationSet never renders an Application whose image does not exist yet.
+- **ArgoCD ApplicationSet** — a PR generator watching the repo for the `preview` label, deploying `<registry>/<repository>:pr-{{ .number }}-{{ .head_sha }}` and routing `preview-host` to it. The label is removed while a build is in flight and applied only after every image is confirmed present, so outside the seconds-wide window noted above the ApplicationSet never renders an Application whose image does not exist.
 - **AWS OIDC** — the repo must be able to assume the ECR push role used by [`sdf-ecr-login`](../sdf-ecr-login) (hence `id-token: write`).
-- **Dockerfile** — at the repo root; the image is built with `context: .` using Buildx with GitHub Actions cache (`type=gha`).
 
 ## Security notes
 
-The workflow runs on `pull_request_target`, which executes in the base repo's context with real secrets and write permissions — including for fork PRs. This is safe here because:
+The workflow runs on `pull_request_target`, which executes in the base repo's context with real secrets and write permissions — including for fork PRs. This is safe because:
 
-- No fork code is checked out or executed before the org-membership gate; the App token is only ever handled by trusted steps.
-- The PR head is checked out only for PRs authored by org members, and only to `docker build` it — no repo scripts are run directly on the runner.
-- Do not add steps to the caller workflow that run PR-controlled code before the action.
+- No fork code is checked out or executed before the org-membership gate; the App token is only ever handled by trusted steps inside `gate`.
+- The PR head is checked out only for PRs whose author, actor, and head-repo owner are all org members, and only to build it.
+- The workflow file and the actions are always taken from the base repo / `stellar/actions@main`, so a fork cannot alter the gate for its own run.
+- The guards described in the caller contract are what keep this true. Building before `gate`, or leaving a post-gate step unguarded, executes untrusted code in a privileged job — do not do it.
 
 ## Teardown
 
-Teardown on close is technically redundant with the ApplicationSet generator (a closed PR leaves its result set anyway), but removing the label explicitly makes it immediate and leaves a trace in the PR timeline.
+Teardown on close is technically redundant with the ApplicationSet generator (a closed PR leaves its result set anyway), but removing the label explicitly makes it immediate and leaves a trace in the PR timeline. The same label removal runs at the start of every build, so a preview is also (deliberately) absent while a new head SHA is being built — a failed or cancelled build leaves the preview down rather than pointing at an image that was never pushed.

--- a/sdf-pr-preview/action.yml
+++ b/sdf-pr-preview/action.yml
@@ -149,7 +149,7 @@ runs:
         push: true
         tags: ${{ steps.ecr.outputs.ecr-registry }}/${{ inputs.ecr-repository }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=max,ignore-error=true
 
     # Applied only after the push succeeds, so the ApplicationSet never
     # renders an Application whose image does not exist yet.

--- a/sdf-pr-preview/gate/action.yml
+++ b/sdf-pr-preview/gate/action.yml
@@ -1,15 +1,24 @@
-# Builds a preview image for org-member PRs, marks the PR so ArgoCD's
-# ApplicationSet picks it up, and comments the URL. Handles teardown when the
-# PR closes. ArgoCD does the actual deploying.
+# Policy half of the PR preview flow. Withdraws the `preview` label, handles
+# teardown on close, and decides whether this PR may have a preview. Emits
+# `member` and `image-tag`; the caller then builds and pushes its own
+# image(s) - guarded by `member` - and calls sdf-pr-preview/publish.
 #
 # Composite actions cannot declare triggers, permissions, or concurrency.
-# The caller workflow must run this on `pull_request_target` (types: opened,
+# The caller workflow must run on `pull_request_target` (types: opened,
 # synchronize, reopened, closed) with `contents: read`, `id-token: write`,
 # `pull-requests: write`, and a per-PR concurrency group.
-# See .github/workflows/pr-preview.yml.
+#
+# Caller contract - the trust boundary now lives in the caller workflow:
+#   - This step MUST run before any step that checks out or executes PR code.
+#   - EVERY later step that touches PR code (checkout, build, push, publish)
+#     MUST carry `if: steps.<gate-id>.outputs.member == 'true'`.
+#   - Check out `github.event.pull_request.head.sha` (not the default base
+#     ref) with `persist-credentials: false`.
+#   - Tag every preview image with `image-tag`, verbatim.
+# See ../README.md.
 
-name: 'PR Preview'
-description: 'Build and publish an ArgoCD-deployed preview image for org-member PRs'
+name: 'PR Preview - Gate'
+description: 'Withdraw the preview signal and decide whether this PR may have a preview'
 
 inputs:
   app-id:
@@ -18,23 +27,36 @@ inputs:
   private-key:
     description: 'Private key of that GitHub App'
     required: true
-  ecr-repository:
-    description: 'ECR repository to push the preview image to (e.g. dev/stellar-design-system)'
-    required: true
-  preview-host:
-    description: 'Hostname the preview will be served on'
-    required: true
+
+outputs:
+  member:
+    description: >-
+      'true' when the event is not `closed` and the PR author, the actor who
+      triggered this run, and the head repository owner are all org members.
+      Anything else (including a `closed` event) is 'false'.
+    value: ${{ steps.check.outputs.member == 'true' }}
+  image-tag:
+    description: >-
+      Tag every preview image must carry: pr-<number>-<head-sha>. Must match
+      what the ApplicationSet renders as pr-{{ .number }}-{{ .head_sha }}.
+    value: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
 
 runs:
   using: composite
   steps:
     # -------------------------------------------------------------------------
-    # PR closed or merged: immediate teardown, then nothing else runs.
-    # Redundant with the generator (a closed PR leaves its result set anyway),
-    # but it makes teardown immediate and leaves a trace in the PR timeline.
+    # Withdraw the signal first, on every event. The ApplicationSet derives
+    # {{ .head_sha }} from the live PR, so on `synchronize` a label left over
+    # from the previous build would let it deploy pr-<number>-<new-sha> before
+    # that image is pushed - and point at a nonexistent tag for as long as
+    # that commit stays the head if the build fails. Removing the label up
+    # front makes the signal fail closed: it is absent whenever the image it
+    # implies might not exist, at the cost of the preview going dark while a
+    # rebuild is in flight.
+    # On `closed` this doubles as immediate teardown (redundant with the
+    # generator - a closed PR leaves its result set anyway - but immediate).
     # -------------------------------------------------------------------------
-    - name: Remove preview label
-      if: github.event.action == 'closed'
+    - name: Disable preview
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -108,66 +130,3 @@ runs:
         if [ "$trusted" = "true" ]; then
           echo "::notice::author, actor, and head repo owner are all members of ${ORG} - preview enabled"
         fi
-
-    # -------------------------------------------------------------------------
-    # Non-member PR: make sure no stale label survives.
-    # Keeps CI authoritative - a hand-applied label cannot create a preview
-    # for an image that was never built.
-    # -------------------------------------------------------------------------
-    - name: Revoke preview label
-      if: github.event.action != 'closed' && steps.check.outputs.member != 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GH_REPO: ${{ github.repository }}
-      run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label preview || true
-
-    # -------------------------------------------------------------------------
-    # Member PR: build, push, then mark the PR.
-    # This checkout replaces the caller's base-ref workspace with the PR head,
-    # not the synthetic merge commit. This SHA must match what the
-    # ApplicationSet injects as {{ .head_sha }}.
-    # -------------------------------------------------------------------------
-    - uses: actions/checkout@v4
-      if: steps.check.outputs.member == 'true'
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        persist-credentials: false
-
-    - uses: docker/setup-buildx-action@v3
-      if: steps.check.outputs.member == 'true'
-
-    # Handles OIDC auth, role assumption, and ECR login internally.
-    - id: ecr
-      if: steps.check.outputs.member == 'true'
-      uses: stellar/actions/sdf-ecr-login@main
-
-    - uses: docker/build-push-action@v6
-      if: steps.check.outputs.member == 'true'
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.ecr.outputs.ecr-registry }}/${{ inputs.ecr-repository }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max,ignore-error=true
-
-    # Applied only after the push succeeds, so the ApplicationSet never
-    # renders an Application whose image does not exist yet.
-    # The `preview` label must already exist in the repo.
-    - name: Enable preview
-      if: steps.check.outputs.member == 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GH_REPO: ${{ github.repository }}
-      run: gh pr edit "${{ github.event.pull_request.number }}" --add-label preview
-
-    - name: Comment preview URL
-      if: steps.check.outputs.member == 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GH_REPO: ${{ github.repository }}
-      run: >-
-        gh pr comment "${{ github.event.pull_request.number }}"
-        --body "PR Preview: https://${{ inputs.preview-host }}"

--- a/sdf-pr-preview/publish/action.yml
+++ b/sdf-pr-preview/publish/action.yml
@@ -1,0 +1,77 @@
+# Signal half of the PR preview flow. Run after the caller has built and
+# pushed its preview image(s). Verifies that every image the preview deploys
+# actually exists in the registry, and only then labels the PR (which is what
+# ArgoCD's ApplicationSet keys on) and comments the URL.
+#
+# The existence check is what upholds the invariant "label present => image
+# exists" now that the build lives in the caller: a miswired build step or a
+# mismatched tag fails here instead of producing a preview that can never
+# start.
+#
+# Must be guarded with `if: steps.<gate-id>.outputs.member == 'true'` in the
+# caller, like every other post-gate step. The registry lookup relies on the
+# docker credentials left on the runner by the caller's registry login
+# (e.g. stellar/actions/sdf-ecr-login), which the caller needed to push anyway.
+
+name: 'PR Preview - Publish'
+description: 'Verify the preview images exist, then label the PR and comment the URL'
+
+inputs:
+  images:
+    description: >-
+      Fully qualified image references (registry/repository:tag) the preview
+      deploys, one per line. Every one must exist before the label is applied.
+    required: true
+  preview-host:
+    description: 'Hostname the preview will be served on'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify preview images exist
+      shell: bash
+      env:
+        IMAGES: ${{ inputs.images }}
+      run: |
+        set -uo pipefail
+        found=0
+        missing=0
+        while IFS= read -r image; do
+          image="$(echo "$image" | xargs)"   # trim
+          [ -z "$image" ] && continue
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            echo "found ${image}"
+            found=$((found + 1))
+          else
+            echo "::error::${image} does not exist in the registry (not pushed, wrong tag, or not logged in)"
+            missing=$((missing + 1))
+          fi
+        done <<< "$IMAGES"
+
+        if [ "$found" -eq 0 ] && [ "$missing" -eq 0 ]; then
+          echo "::error::'images' is empty - at least one image reference is required"
+          exit 1
+        fi
+        [ "$missing" -eq 0 ]
+
+    # Applied only after every image is confirmed present. Combined with the
+    # up-front removal in `gate`, the label is present only while the images
+    # it implies exist: a failed or cancelled build leaves the label off,
+    # never a broken preview. The `preview` label must already exist in the
+    # repo.
+    - name: Enable preview
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: gh pr edit "${{ github.event.pull_request.number }}" --add-label preview
+
+    - name: Comment preview URL
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      run: >-
+        gh pr comment "${{ github.event.pull_request.number }}"
+        --body "PR Preview: https://${{ inputs.preview-host }}"


### PR DESCRIPTION
### What:


The composite action owned the docker build, which does not fit repos that build several images or use their own tooling (make targets, non-root Dockerfiles). Letting the caller build *before* the action is not an option: under pull_request_target the org-membership check must run before any fork code is checked out or executed. So the action is split at the two points where the trust boundary sits:

- sdf-pr-preview/gate: withdraw the `preview` label, tear down on close, check that author, actor, and head repo owner are all org members -> outputs `member`, `image-tag`
- caller builds/pushes: every step guarded by member == 'true', every image tagged with `image-tag`
- sdf-pr-preview/publish: verify each listed image exists in the registry, then label the PR and comment the URL

Two behavioural changes ride along:

- The label is now removed at the start of every run, not only on close. ArgoCD's ApplicationSet derives head_sha from the live PR, so a label left over from a previous build let it deploy the new SHA's tag before the image was pushed - and keep pointing at a nonexistent tag if the build failed. Re-adding an already-present label after the push gave no ordering guarantee. The signal now fails closed: present only while the images it implies exist, at the cost of the preview going dark during a rebuild.

- `publish` checks image existence (`docker manifest inspect`) before labelling. With the build in the caller, this is what upholds "label present => image exists" against a miswired build step or a tag that drifts from what the ApplicationSet renders.

The all-in-one wrapper is dropped rather than kept alongside: one documented path is clearer than two, and no consumer needs the root-Dockerfile default. Callers of stellar/actions/sdf-pr-preview@main must move to gate + publish; the README example is a drop-in template.



### Why:


We do not have uniform build steps for all repos.